### PR TITLE
add configuration for tls context on listener

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,12 +37,16 @@ type config struct {
 	IngressClass string          `json:"ingressClass"`
 	NodeName     string          `json:"nodeName"`
 	Clusters     []clusterConfig `json:"clusters"`
+	Cert         string          `json:"cert"`
+	Key          string          `json:"key"`
 }
 
 var (
 	ingressClass string
 	nodeName     string
 	sources      []k8scache.ListerWatcher
+	cert         string
+	key          string
 )
 
 // Hasher returns node ID as an ID
@@ -112,7 +116,7 @@ func main() {
 	envoyCache := cache.NewSnapshotCache(false, hash, nil)
 
 	lister := k8s.NewIngressAggregator(sources)
-	configurator := envoy.NewKubernetesConfigurator(lister, ingressClass, nodeName)
+	configurator := envoy.NewKubernetesConfigurator(lister, ingressClass, nodeName, cert, key)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, lister.Events())
 	go snapshotter.Run(ctx)
 	lister.Run(ctx)
@@ -143,6 +147,8 @@ func parseConfig(path string) error {
 
 	ingressClass = conf.IngressClass
 	nodeName = conf.NodeName
+	cert = conf.Cert
+	key = conf.Key
 
 	for _, cluster := range conf.Clusters {
 		config := &rest.Config{

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -14,6 +14,8 @@ type KubernetesConfigurator struct {
 	lister       k8s.IngressLister
 	ingressClass string
 	nodeID       string
+	cert         string
+	key          string
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string
@@ -22,8 +24,8 @@ type KubernetesConfigurator struct {
 }
 
 //NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
-func NewKubernetesConfigurator(lister k8s.IngressLister, ingressClass, nodeID string) *KubernetesConfigurator {
-	return &KubernetesConfigurator{lister: lister, ingressClass: ingressClass, nodeID: nodeID}
+func NewKubernetesConfigurator(lister k8s.IngressLister, ingressClass, nodeID, cert, key string) *KubernetesConfigurator {
+	return &KubernetesConfigurator{lister: lister, ingressClass: ingressClass, nodeID: nodeID, cert: cert, key: key}
 }
 
 //Generate creates a new snapshot
@@ -54,7 +56,7 @@ func (c *KubernetesConfigurator) generateSnapshot(config *envoyConfiguration) ca
 	for _, virtualHost := range config.VirtualHosts {
 		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost.Host, timeout))
 	}
-	listener := makeListener(virtualHosts)
+	listener := makeListener(virtualHosts, c.cert, c.key)
 
 	clusterItems := []cache.Resource{}
 	for _, cluster := range config.Clusters {


### PR DESCRIPTION
This allows you to add a key and cert for the listener. if not set it will be ignored. I feel like the way we're handling config has got a bit messy now so I'm gonna do a separate PR to clean up flags/config potentially using cobra/viper