### PR TITLE
add option to set trusted ca

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ type config struct {
 	Clusters     []clusterConfig `json:"clusters"`
 	Cert         string          `json:"cert"`
 	Key          string          `json:"key"`
+	TrustCA      string          `json:"trustCA"`
 }
 
 // Hasher returns node ID as an ID
@@ -64,6 +65,7 @@ func init() {
 	rootCmd.PersistentFlags().String("node-name", "", "envoy node name")
 	rootCmd.PersistentFlags().String("cert", "", "certfile")
 	rootCmd.PersistentFlags().String("key", "", "keyfile")
+	rootCmd.PersistentFlags().String("ca", "", "trustedCA")
 	rootCmd.PersistentFlags().String("ingress-class", "", "Ingress class to watch")
 	rootCmd.PersistentFlags().StringArrayVar(&kubeConfig, "kube-config", nil, "Path to kube config")
 	rootCmd.PersistentFlags().Bool("debug", false, "Log at debug level")
@@ -72,6 +74,7 @@ func init() {
 	viper.BindPFlag("ingressClass", rootCmd.PersistentFlags().Lookup("ingress-class"))
 	viper.BindPFlag("cert", rootCmd.PersistentFlags().Lookup("cert"))
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
+	viper.BindPFlag("trustCA", rootCmd.PersistentFlags().Lookup("ca"))
 }
 
 func initConfig() {
@@ -116,7 +119,7 @@ func main(*cobra.Command, []string) error {
 	envoyCache := cache.NewSnapshotCache(false, hash, nil)
 
 	lister := k8s.NewIngressAggregator(sources)
-	configurator := envoy.NewKubernetesConfigurator(lister, viper.GetString("ingressClass"), viper.GetString("nodeName"), viper.GetString("cert"), viper.GetString("key"))
+	configurator := envoy.NewKubernetesConfigurator(lister, viper.GetString("ingressClass"), viper.GetString("nodeName"), viper.GetString("cert"), viper.GetString("key"), viper.GetString("trustCA"))
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, lister.Events())
 	go snapshotter.Run(ctx)
 	lister.Run(ctx)

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -122,12 +122,28 @@ func makeAddresses(addresses []string) []*core.Address {
 	return envoyAddresses
 }
 
-func makeCluster(host string, addresses []*core.Address) *v2.Cluster {
+func makeCluster(host, ca string, addresses []*core.Address) *v2.Cluster {
+
+	tls := &auth.UpstreamTlsContext{}
+	if ca != "" {
+		tls.CommonTlsContext = &auth.CommonTlsContext{
+			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_Filename{Filename: ca},
+					},
+				},
+			},
+		}
+	} else {
+		tls = nil
+	}
 	cluster := &v2.Cluster{
 		Type:           v2.Cluster_STRICT_DNS,
 		Name:           host,
 		ConnectTimeout: time.Second * 30,
 		Hosts:          addresses,
+		TlsContext:     tls,
 	}
 	return cluster
 }

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -16,6 +16,7 @@ type KubernetesConfigurator struct {
 	nodeID       string
 	cert         string
 	key          string
+	trustCA      string
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string
@@ -24,8 +25,8 @@ type KubernetesConfigurator struct {
 }
 
 //NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
-func NewKubernetesConfigurator(lister k8s.IngressLister, ingressClass, nodeID, cert, key string) *KubernetesConfigurator {
-	return &KubernetesConfigurator{lister: lister, ingressClass: ingressClass, nodeID: nodeID, cert: cert, key: key}
+func NewKubernetesConfigurator(lister k8s.IngressLister, ingressClass, nodeID, cert, key, ca string) *KubernetesConfigurator {
+	return &KubernetesConfigurator{lister: lister, ingressClass: ingressClass, nodeID: nodeID, cert: cert, key: key, trustCA: ca}
 }
 
 //Generate creates a new snapshot
@@ -61,7 +62,7 @@ func (c *KubernetesConfigurator) generateSnapshot(config *envoyConfiguration) ca
 	clusterItems := []cache.Resource{}
 	for _, cluster := range config.Clusters {
 		addresses := makeAddresses(cluster.Hosts)
-		cluster := makeCluster(cluster.Name, addresses)
+		cluster := makeCluster(cluster.Name, c.trustCA, addresses)
 		clusterItems = append(clusterItems, cluster)
 	}
 


### PR DESCRIPTION
This allows you to tell the envoy nodes what CA to use when it communicates with the https endpoints.