### PR TITLE
allow healthcheck path configuration via annotations

### DIFF
--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -62,7 +62,7 @@ func (c *KubernetesConfigurator) generateSnapshot(config *envoyConfiguration) ca
 	clusterItems := []cache.Resource{}
 	for _, cluster := range config.Clusters {
 		addresses := makeAddresses(cluster.Hosts)
-		cluster := makeCluster(cluster.Name, c.trustCA, addresses)
+		cluster := makeCluster(cluster.Name, c.trustCA, cluster.HealthCheckPath, addresses)
 		clusterItems = append(clusterItems, cluster)
 	}
 


### PR DESCRIPTION
This reads the ingress annotations to allow a custom health check path to be used.

Do we think this should just put a `/` in or do we assume people have configured the `/` themselves or should we error? I'm not sure