### PR TITLE
log to stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -92,6 +93,7 @@ func initConfig() {
 }
 
 func main(*cobra.Command, []string) error {
+	flag.Set("logtostderr", "true")
 	var c config
 	err := viper.Unmarshal(&c)
 	if err != nil {


### PR DESCRIPTION
This stop it from trying to write to a log file on error which can cause a fatal error in a FROM scratch container