### PR TITLE
make connection timeout configurable via annotations

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -177,7 +177,7 @@ func makeAddresses(addresses []string) []*core.Address {
 	return envoyAddresses
 }
 
-func makeCluster(host, ca, healthPath string, addresses []*core.Address) *v2.Cluster {
+func makeCluster(host, ca, healthPath string, timeout time.Duration, addresses []*core.Address) *v2.Cluster {
 
 	tls := &auth.UpstreamTlsContext{}
 	if ca != "" {
@@ -196,7 +196,7 @@ func makeCluster(host, ca, healthPath string, addresses []*core.Address) *v2.Clu
 	cluster := &v2.Cluster{
 		Type:           v2.Cluster_STRICT_DNS,
 		Name:           host,
-		ConnectTimeout: time.Second * 30,
+		ConnectTimeout: timeout,
 		Hosts:          addresses,
 		TlsContext:     tls,
 		HealthChecks: []*core.HealthCheck{&core.HealthCheck{

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -62,7 +62,7 @@ func (c *KubernetesConfigurator) generateSnapshot(config *envoyConfiguration) ca
 	clusterItems := []cache.Resource{}
 	for _, cluster := range config.Clusters {
 		addresses := makeAddresses(cluster.Hosts)
-		cluster := makeCluster(cluster.Name, c.trustCA, cluster.HealthCheckPath, addresses)
+		cluster := makeCluster(cluster.Name, c.trustCA, cluster.HealthCheckPath, cluster.Timeout, addresses)
 		clusterItems = append(clusterItems, cluster)
 	}
 


### PR DESCRIPTION
This adds a new annotations of `yggdrasil.uswitch.com/timeout` which allows you to set the connection timeout for your ingress. By default it was 30s, but for certain services they may need longer than this, such as things doing complicated computations. 

If decide to add more annotations for yggdrasil we will probably need to refactor the code to make arbitrary config annotations easier to implement as having a giant block of "if annotation exists" will not be ideal.