### PR TITLE
Only health check ingresses that define health check paths

### DIFF
--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -146,7 +146,7 @@ func translateIngresses(ingresses []v1beta1.Ingress) *envoyConfiguration {
 				if i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"] != "" {
 					ingressHealthChecks[rule.Host] = i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"]
 				} else {
-					ingressHealthChecks[rule.Host] = "/"
+					ingressHealthChecks[rule.Host] = ""
 				}
 
 				if i.GetAnnotations()["yggdrasil.uswitch.com/timeout"] != "" {


### PR DESCRIPTION
This removes the default "/" health check in favour of only creating health checks when it's defined on the target ingress.