### PR TITLE
Timeouts

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -50,10 +50,10 @@ func init() {
 	jsonFormat = string(b) + "\n"
 }
 
-func makeVirtualHost(host string, timeout time.Duration) route.VirtualHost {
+func makeVirtualHost(vhost *virtualHost) route.VirtualHost {
 	virtualHost := route.VirtualHost{
 		Name:    "local_service",
-		Domains: []string{host},
+		Domains: []string{vhost.Host},
 		Routes: []route.Route{route.Route{
 			Match: route.RouteMatch{
 				PathSpecifier: &route.RouteMatch_Prefix{
@@ -62,12 +62,13 @@ func makeVirtualHost(host string, timeout time.Duration) route.VirtualHost {
 			},
 			Action: &route.Route_Route{
 				Route: &route.RouteAction{
+					Timeout: &vhost.Timeout,
 					ClusterSpecifier: &route.RouteAction_Cluster{
-						Cluster: host,
+						Cluster: vhost.Host,
 					},
 					RetryPolicy: &route.RouteAction_RetryPolicy{
 						RetryOn:       "5xx",
-						PerTryTimeout: &timeout,
+						PerTryTimeout: &vhost.PerTryTimeout,
 					},
 				},
 			},

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -52,10 +52,9 @@ func (c *KubernetesConfigurator) generateSnapshot(config *envoyConfiguration) ca
 
 	vmatch, cmatch := config.equals(c.previousConfig)
 
-	timeout := time.Second * 5
 	virtualHosts := []route.VirtualHost{}
 	for _, virtualHost := range config.VirtualHosts {
-		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost.Host, timeout))
+		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost))
 	}
 	listener := makeListener(virtualHosts, c.cert, c.key)
 

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -146,10 +146,10 @@ func newEnvoyIngress(host string) *envoyIngress {
 			PerTryTimeout: (5 * time.Second),
 		},
 		cluster: &cluster{
-			Name:    host,
-			Hosts:   []string{},
-			Timeout: (30 * time.Second),
-			HealthCheckPath: ""
+			Name:            host,
+			Hosts:           []string{},
+			Timeout:         (30 * time.Second),
+			HealthCheckPath: "",
 		},
 	}
 }

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -59,7 +59,9 @@ type envoyConfiguration struct {
 }
 
 type virtualHost struct {
-	Host string
+	Host          string
+	Timeout       time.Duration
+	PerTryTimeout time.Duration
 }
 
 func (v *virtualHost) Equals(other *virtualHost) bool {
@@ -165,7 +167,10 @@ func translateIngresses(ingresses []v1beta1.Ingress) *envoyConfiguration {
 			Hosts:           hosts,
 			HealthCheckPath: ingressHealthChecks[ingress],
 			Timeout:         ingressTimeouts[ingress]})
-		cfg.VirtualHosts = append(cfg.VirtualHosts, &virtualHost{Host: ingress})
+		cfg.VirtualHosts = append(cfg.VirtualHosts, &virtualHost{
+			Host:          ingress,
+			Timeout:       ingressTimeouts[ingress],
+			PerTryTimeout: ingressTimeouts[ingress]})
 	}
 
 	numVhosts.Set(float64(len(cfg.VirtualHosts)))

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -149,6 +149,7 @@ func newEnvoyIngress(host string) *envoyIngress {
 			Name:    host,
 			Hosts:   []string{},
 			Timeout: (30 * time.Second),
+			HealthCheckPath: ""
 		},
 	}
 }

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -133,44 +133,72 @@ func classFilter(ingresses []v1beta1.Ingress, ingressClass []string) []v1beta1.I
 	return is
 }
 
+type envoyIngress struct {
+	vhost   *virtualHost
+	cluster *cluster
+}
+
+func newEnvoyIngress(host string) *envoyIngress {
+	return &envoyIngress{
+		vhost: &virtualHost{
+			Host:          host,
+			Timeout:       (15 * time.Second),
+			PerTryTimeout: (5 * time.Second),
+		},
+		cluster: &cluster{
+			Name:    host,
+			Hosts:   []string{},
+			Timeout: (30 * time.Second),
+		},
+	}
+}
+
+func (ing *envoyIngress) addUpstream(host string) {
+	ing.cluster.Hosts = append(ing.cluster.Hosts, host)
+}
+
+func (ing *envoyIngress) addHealthCheckPath(path string) {
+	ing.cluster.HealthCheckPath = path
+}
+
+func (ing *envoyIngress) addTimeout(timeout time.Duration) {
+	ing.cluster.Timeout = timeout
+	ing.vhost.Timeout = timeout
+	ing.vhost.PerTryTimeout = timeout
+}
+
 func translateIngresses(ingresses []v1beta1.Ingress) *envoyConfiguration {
 	cfg := &envoyConfiguration{}
-	ingressToStatusHosts := map[string][]string{}
-	ingressHealthChecks := map[string]string{}
-	ingressTimeouts := map[string]time.Duration{}
+	envoyIngresses := map[string]*envoyIngress{}
 
 	for _, i := range ingresses {
 		for _, j := range i.Status.LoadBalancer.Ingress {
 			for _, rule := range i.Spec.Rules {
-				ingressToStatusHosts[rule.Host] = append(ingressToStatusHosts[rule.Host], j.Hostname)
-				ingressTimeouts[rule.Host] = time.Second * 30
+				_, ok := envoyIngresses[rule.Host]
+				if !ok {
+					envoyIngresses[rule.Host] = newEnvoyIngress(rule.Host)
+				}
+
+				envoyIngress := envoyIngresses[rule.Host]
+				envoyIngress.addUpstream(j.Hostname)
 
 				if i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"] != "" {
-					ingressHealthChecks[rule.Host] = i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"]
-				} else {
-					ingressHealthChecks[rule.Host] = ""
+					envoyIngress.addHealthCheckPath(i.GetAnnotations()["yggdrasil.uswitch.com/healthcheck-path"])
 				}
 
 				if i.GetAnnotations()["yggdrasil.uswitch.com/timeout"] != "" {
 					timeout, err := time.ParseDuration(i.GetAnnotations()["yggdrasil.uswitch.com/timeout"])
 					if err == nil {
-						ingressTimeouts[rule.Host] = timeout
+						envoyIngress.addTimeout(timeout)
 					}
 				}
 			}
 		}
 	}
 
-	for ingress, hosts := range ingressToStatusHosts {
-		cfg.Clusters = append(cfg.Clusters, &cluster{
-			Name:            ingress,
-			Hosts:           hosts,
-			HealthCheckPath: ingressHealthChecks[ingress],
-			Timeout:         ingressTimeouts[ingress]})
-		cfg.VirtualHosts = append(cfg.VirtualHosts, &virtualHost{
-			Host:          ingress,
-			Timeout:       ingressTimeouts[ingress],
-			PerTryTimeout: ingressTimeouts[ingress]})
+	for _, ingress := range envoyIngresses {
+		cfg.Clusters = append(cfg.Clusters, ingress.cluster)
+		cfg.VirtualHosts = append(cfg.VirtualHosts, ingress.vhost)
 	}
 
 	numVhosts.Set(float64(len(cfg.VirtualHosts)))


### PR DESCRIPTION
This makes Yggdrasil configure the [Route timeout](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-timeout) and [PerTryTimeout](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-per-try-timeout) to the same value as it currently sets the Cluster's [ConnectTimeout](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v1/cluster_manager/cluster.html#config-cluster-manager-type)

This will bring all timeouts in Envoy inline for now. Previously due to the PerTry timeout being coded to 5s all actions were aborted after 5s and the maximum time a request would last would be around 15s (the default for RouteAction.Timeout).

In the future we may want to split these into different annotations again to allow for more flexible configuration per ingress.

