### PR TITLE
Should check equality for all timeouts as well

### DIFF
--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -69,7 +69,9 @@ func (v *virtualHost) Equals(other *virtualHost) bool {
 		return false
 	}
 
-	return v.Host == other.Host
+	return v.Host == other.Host &&
+		v.Timeout == other.Timeout &&
+		v.PerTryTimeout == other.PerTryTimeout
 }
 
 type cluster struct {
@@ -89,6 +91,10 @@ func (c *cluster) Equals(other *cluster) bool {
 	}
 
 	if c.Name != other.Name {
+		return false
+	}
+
+	if c.Timeout != other.Timeout {
 		return false
 	}
 

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -2,6 +2,7 @@ package envoy
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -19,6 +20,16 @@ func TestVirtualHostEquality(t *testing.T) {
 	c := &virtualHost{Host: ""}
 	if a.Equals(c) {
 		t.Error()
+	}
+
+	d := &virtualHost{Host: "foo", Timeout: (5 * time.Second)}
+	if a.Equals(d) {
+		t.Error("virtual hosts with different timeout values should not be equal")
+	}
+
+	e := &virtualHost{Host: "foo", PerTryTimeout: (5 * time.Second)}
+	if a.Equals(e) {
+		t.Error("virtual hosts with different per try timeout values should not be equal")
 	}
 }
 
@@ -48,6 +59,11 @@ func TestClusterEquality(t *testing.T) {
 	f := &cluster{Name: "foo"}
 	if a.Equals(f) {
 		t.Error("no hosts set")
+	}
+
+	g := &cluster{Name: "foo", Hosts: []string{"host1", "host2"}, Timeout: (5 * time.Second)}
+	if a.Equals(g) {
+		t.Error("clusters with different timeout values should not be equal")
 	}
 }
 


### PR DESCRIPTION
We should take the values of the timeouts into consideration when updating snapshots