### PR TITLE
Match all certificates, not just the most specific

### DIFF
--- a/pkg/envoy/configurator_test.go
+++ b/pkg/envoy/configurator_test.go
@@ -123,22 +123,23 @@ func TestGenerateNoMatchingCert(t *testing.T) {
 	}
 }
 
-func TestGenerateMatchesMostSpecific(t *testing.T) {
+func TestGenerateIntoTwoCerts(t *testing.T) {
 	ingresses := []v1beta1.Ingress{
 		newIngress("foo.internal.api.com", "bibble"),
 	}
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
-		{ Hosts: []string{"*"}, Cert: "wild", Key: "wild", },
 		{ Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com", },
+		{ Hosts: []string{"*.internal.api.com"}, Cert: "all", Key: "all", },
 	}, "d", []string{"bar"})
 
 	snapshot := configurator.Generate(ingresses)
 	listener := snapshot.Listeners.Items["listener_0"].(*v2.Listener)
 
-	if len(listener.FilterChains) != 1 {
-		t.Fatalf("Num filter chains: %d expected %d", len(listener.FilterChains), 1)
+	if len(listener.FilterChains) != 2 {
+		t.Fatalf("Num filter chains: %d expected %d", len(listener.FilterChains), 2)
 	}
 
-	assertTlsCertificate(t, listener.FilterChains[0], "com", "com")
+	assertNumberOfVirtualHosts(t, listener.FilterChains[0], 1)
+	assertNumberOfVirtualHosts(t, listener.FilterChains[1], 1)
 }


### PR DESCRIPTION
We are currently transitioning from ALBs that terminate the TLS to
NLBs move the termination through to Envoy. ALBs do not open the TLS
connection to the upstream using the same server name as was received
by that. This means the Envoy can't match on SNI and it fails out.

The documentation from envoy: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener.proto#listener-filterchainmatch
seems to indicate that the most specific FilterChaniMatch will rule
so we can differ this picking of which certificate to Envoy at runtime.