### PR TITLE
Remove dots from the cluster name

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -59,7 +59,7 @@ func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) route.Virtua
 		Route: &route.RouteAction{
 			Timeout: &vhost.Timeout,
 			ClusterSpecifier: &route.RouteAction_Cluster{
-				Cluster: vhost.Host,
+				Cluster: vhost.UpstreamCluster,
 			},
 			RetryPolicy: &route.RouteAction_RetryPolicy{
 				RetryOn:       "5xx",

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -2,6 +2,7 @@ package envoy
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/api/extensions/v1beta1"
@@ -152,7 +153,7 @@ func newEnvoyIngress(host string) *envoyIngress {
 			PerTryTimeout: (5 * time.Second),
 		},
 		cluster: &cluster{
-			Name:            host,
+			Name:            strings.ReplaceAll(host, ".", "_"),
 			Hosts:           []string{},
 			Timeout:         (30 * time.Second),
 			HealthCheckPath: "",

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -60,9 +60,10 @@ type envoyConfiguration struct {
 }
 
 type virtualHost struct {
-	Host          string
-	Timeout       time.Duration
-	PerTryTimeout time.Duration
+	Host            string
+	UpstreamCluster string
+	Timeout         time.Duration
+	PerTryTimeout   time.Duration
 }
 
 func (v *virtualHost) Equals(other *virtualHost) bool {
@@ -72,6 +73,7 @@ func (v *virtualHost) Equals(other *virtualHost) bool {
 
 	return v.Host == other.Host &&
 		v.Timeout == other.Timeout &&
+		v.UpstreamCluster == other.UpstreamCluster &&
 		v.PerTryTimeout == other.PerTryTimeout
 }
 
@@ -146,14 +148,16 @@ type envoyIngress struct {
 }
 
 func newEnvoyIngress(host string) *envoyIngress {
+	clusterName := strings.ReplaceAll(host, ".", "_")
 	return &envoyIngress{
 		vhost: &virtualHost{
-			Host:          host,
-			Timeout:       (15 * time.Second),
-			PerTryTimeout: (5 * time.Second),
+			Host:            host,
+			UpstreamCluster: clusterName,
+			Timeout:         (15 * time.Second),
+			PerTryTimeout:   (5 * time.Second),
 		},
 		cluster: &cluster{
-			Name:            strings.ReplaceAll(host, ".", "_"),
+			Name:            clusterName,
 			Hosts:           []string{},
 			Timeout:         (30 * time.Second),
 			HealthCheckPath: "",

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -148,7 +148,7 @@ type envoyIngress struct {
 }
 
 func newEnvoyIngress(host string) *envoyIngress {
-	clusterName := strings.ReplaceAll(host, ".", "_")
+	clusterName := strings.Replace(host, ".", "_", -1)
 	return &envoyIngress{
 		vhost: &virtualHost{
 			Host:            host,

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -154,11 +154,15 @@ func TestGeneratesForSingleIngress(t *testing.T) {
 		t.Error("expected 1 clusters")
 	}
 
-	if c.Clusters[0].Name != "foo.app.com" {
+	if c.Clusters[0].Name != "foo_app_com" {
 		t.Errorf("expected cluster to be named after ingress host, was %s", c.Clusters[0].Name)
 	}
 	if c.Clusters[0].Hosts[0] != "foo.cluster.com" {
 		t.Errorf("expected cluster host for foo.cluster.com, was %s", c.Clusters[0].Hosts[0])
+	}
+
+	if c.VirtualHosts[0].UpstreamCluster != c.Clusters[0].Name {
+		t.Errorf("expected upstream cluster of vHost the same as the generated cluster, was %s and %s", c.VirtualHosts[0].UpstreamCluster, c.Clusters[0].Name)
 	}
 }
 
@@ -178,7 +182,7 @@ func TestGeneratesForMultipleIngressSharingSpecHost(t *testing.T) {
 		t.Errorf("expected 1 clusters, was %d", len(c.Clusters))
 	}
 
-	if c.Clusters[0].Name != "app.com" {
+	if c.Clusters[0].Name != "app_com" {
 		t.Errorf("expected cluster to be named after ingress host, was %s", c.Clusters[0].Name)
 	}
 
@@ -190,6 +194,10 @@ func TestGeneratesForMultipleIngressSharingSpecHost(t *testing.T) {
 	}
 	if c.Clusters[0].Hosts[1] != "bar.com" {
 		t.Errorf("expected cluster host for bar.com, was %s", c.Clusters[0].Hosts[1])
+	}
+
+	if c.VirtualHosts[0].UpstreamCluster != c.Clusters[0].Name {
+		t.Errorf("expected upstream cluster of vHost the same as the generated cluster, was %s and %s", c.VirtualHosts[0].UpstreamCluster, c.Clusters[0].Name)
 	}
 }
 


### PR DESCRIPTION
This is a work around for https://github.com/envoyproxy/envoy/issues/4357.
This workaround gives sane prometheus metrics.