### PR TITLE
Dont retry previous host

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,14 +31,15 @@ type clusterConfig struct {
 }
 
 type config struct {
-	IngressClass          string              `json:"ingressClass"`
-	NodeName              string              `json:"nodeName"`
-	Clusters              []clusterConfig     `json:"clusters"`
-	Certificates          []envoy.Certificate `json:"certificates"`
-	TrustCA               string              `json:"trustCA"`
-	UpstreamPort          uint32              `json:"upstreamPort"`
-	EnvoyPort             uint32              `json:"envoyPort"`
-	MaxEjectionPercentage uint32              `json:"maxEjectionPercentage"`
+	IngressClass               string              `json:"ingressClass"`
+	NodeName                   string              `json:"nodeName"`
+	Clusters                   []clusterConfig     `json:"clusters"`
+	Certificates               []envoy.Certificate `json:"certificates"`
+	TrustCA                    string              `json:"trustCA"`
+	UpstreamPort               uint32              `json:"upstreamPort"`
+	EnvoyPort                  uint32              `json:"envoyPort"`
+	MaxEjectionPercentage      uint32              `json:"maxEjectionPercentage"`
+	HostSelectionRetryAttempts int64               `json:"hostSelectionRetryAttempts"`
 }
 
 // Hasher returns node ID as an ID
@@ -79,6 +80,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint32("upstream-port", 443, "port used to connect to the upstream ingresses")
 	rootCmd.PersistentFlags().Uint32("envoy-port", 10000, "port by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Int32("max-ejection-percentage", -1, "maximal percentage of hosts ejected via outlier detection. Set to >=0 to activate outlier detection in envoy.")
+	rootCmd.PersistentFlags().Int64("host-selection-retry-attempts", -1, "Number of host selection retry attempts. Set to value >=0 to enable")
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
@@ -90,6 +92,7 @@ func init() {
 	viper.BindPFlag("upstreamPort", rootCmd.PersistentFlags().Lookup("upstream-port"))
 	viper.BindPFlag("envoyPort", rootCmd.PersistentFlags().Lookup("envoy-port"))
 	viper.BindPFlag("maxEjectionPercentage", rootCmd.PersistentFlags().Lookup("max-ejection-percentage"))
+	viper.BindPFlag("hostSelectionRetryAttempts", rootCmd.PersistentFlags().Lookup("host-selection-retry-attempts"))
 }
 
 func initConfig() {
@@ -170,6 +173,7 @@ func main(*cobra.Command, []string) error {
 		envoy.WithUpstreamPort(uint32(viper.GetInt32("upstreamPort"))),
 		envoy.WithEnvoyPort(uint32(viper.GetInt32("envoyPort"))),
 		envoy.WithOutlierPercentage(viper.GetInt32("maxEjectionPercentage")),
+		envoy.WithHostSelectionRetryAttempts(viper.GetInt64("hostSelectionRetryAttempts")),
 	)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, lister)
 

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -71,6 +71,12 @@ func makeVirtualHost(vhost *virtualHost) route.VirtualHost {
 					RetryPolicy: &route.RouteAction_RetryPolicy{
 						RetryOn:       "5xx",
 						PerTryTimeout: &vhost.PerTryTimeout,
+						RetryHostPredicate: []*route.RouteAction_RetryPolicy_RetryHostPredicate{
+							{
+								Name: "envoy.retry_host_predicates.previous_hosts",
+							},
+						},
+						HostSelectionRetryMaxAttempts: 3,
 					},
 				},
 			},

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -21,13 +21,14 @@ type Certificate struct {
 
 //KubernetesConfigurator takes a given Ingress Class and lister to find only ingresses of that class
 type KubernetesConfigurator struct {
-	ingressClasses    []string
-	nodeID            string
-	certificates      []Certificate
-	trustCA           string
-	upstreamPort      uint32
-	envoyListenPort   uint32
-	outlierPercentage int32
+	ingressClasses             []string
+	nodeID                     string
+	certificates               []Certificate
+	trustCA                    string
+	upstreamPort               uint32
+	envoyListenPort            uint32
+	outlierPercentage          int32
+	hostSelectionRetryAttempts int64
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string
@@ -125,7 +126,7 @@ func (c *KubernetesConfigurator) generateListeners(config *envoyConfiguration) [
 			log.Printf("Error matching certificate for '%s': %v", virtualHost.Host, err)
 		} else {
 			for _, idx := range certificateIndicies {
-				virtualHostsForCertificates[idx] = append(virtualHostsForCertificates[idx], makeVirtualHost(virtualHost))
+				virtualHostsForCertificates[idx] = append(virtualHostsForCertificates[idx], makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts))
 			}
 		}
 	}

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -22,3 +22,11 @@ func WithOutlierPercentage(percentage int32) option {
 		c.outlierPercentage = percentage
 	}
 }
+
+// WithHostSelectionRetryAttempts configures number of host selection reattempts into a KubernetesConfigurator
+func WithHostSelectionRetryAttempts(attempts int64) option {
+	return func(c *KubernetesConfigurator) {
+		c.hostSelectionRetryAttempts = attempts
+
+	}
+}


### PR DESCRIPTION
We use this to balance to other clusters if the one of the backend clusters failed an request.