### PR TITLE
Set hostname in upstream health checks

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -240,7 +241,7 @@ func makeAddresses(addresses []string, upstreamPort uint32) []*core.Address {
 	return envoyAddresses
 }
 
-func makeHealthChecks(healthPath string, config UpstreamHealthCheck) []*core.HealthCheck {
+func makeHealthChecks(clusterName string, healthPath string, config UpstreamHealthCheck) []*core.HealthCheck {
 	healthChecks := []*core.HealthCheck{}
 
 	if healthPath != "" {
@@ -251,6 +252,7 @@ func makeHealthChecks(healthPath string, config UpstreamHealthCheck) []*core.Hea
 			HealthyThreshold:   &types.UInt32Value{Value: config.HealthyThreshold},
 			HealthChecker: &core.HealthCheck_HttpHealthCheck_{
 				HttpHealthCheck: &core.HealthCheck_HttpHealthCheck{
+					Host: strings.Replace(clusterName, "_", ".", -1),
 					Path: healthPath,
 				},
 			},
@@ -261,7 +263,7 @@ func makeHealthChecks(healthPath string, config UpstreamHealthCheck) []*core.Hea
 	return healthChecks
 }
 
-func makeCluster(host, ca, healthPath string, healthCfg UpstreamHealthCheck, timeout time.Duration, outlierPercentage int32, addresses []*core.Address) *v2.Cluster {
+func makeCluster(clusterName, ca, healthPath string, healthCfg UpstreamHealthCheck, timeout time.Duration, outlierPercentage int32, addresses []*core.Address) *v2.Cluster {
 
 	tls := &auth.UpstreamTlsContext{}
 	if ca != "" {
@@ -277,7 +279,7 @@ func makeCluster(host, ca, healthPath string, healthCfg UpstreamHealthCheck, tim
 	} else {
 		tls = nil
 	}
-	healthChecks := makeHealthChecks(healthPath, healthCfg)
+	healthChecks := makeHealthChecks(clusterName, healthPath, healthCfg)
 
 	endpoints := make([]endpoint.LbEndpoint, len(addresses))
 
@@ -289,10 +291,10 @@ func makeCluster(host, ca, healthPath string, healthCfg UpstreamHealthCheck, tim
 
 	cluster := &v2.Cluster{
 		Type:           v2.Cluster_STRICT_DNS,
-		Name:           host,
+		Name:           clusterName,
 		ConnectTimeout: timeout,
 		LoadAssignment: &v2.ClusterLoadAssignment{
-			ClusterName: host,
+			ClusterName: clusterName,
 			Endpoints: []endpoint.LocalityLbEndpoints{
 				{LbEndpoints: endpoints},
 			},

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
 func TestMakeHealthChecksEmptyPath(t *testing.T) {
-	healthChecks := makeHealthChecks("", UpstreamHealthCheck{})
+	healthChecks := makeHealthChecks("example.com", "", UpstreamHealthCheck{})
 
 	if len(healthChecks) != 0 {
 		t.Error("Expected healthchecks to be empty")
@@ -15,13 +17,14 @@ func TestMakeHealthChecksEmptyPath(t *testing.T) {
 }
 
 func TestMakeHealthChecksValidPath(t *testing.T) {
+	host, path := "foo", "/bobba"
 	cfg := UpstreamHealthCheck{
 		Timeout:            mustParseDuration("5s"),
 		Interval:           mustParseDuration("10s"),
 		UnhealthyThreshold: 3,
 		HealthyThreshold:   3,
 	}
-	healthChecks := makeHealthChecks("/bobba", cfg)
+	healthChecks := makeHealthChecks(host, path, cfg)
 	timeout := healthChecks[0].Timeout
 	interval := healthChecks[0].Interval
 
@@ -36,6 +39,17 @@ func TestMakeHealthChecksValidPath(t *testing.T) {
 	if cfg.Interval != *interval {
 		t.Errorf("Expected interval to be %s, but got %s", cfg.Interval, interval)
 	}
+
+	httpCheck := healthChecks[0].HealthChecker.(*core.HealthCheck_HttpHealthCheck_)
+
+	if httpCheck.HttpHealthCheck.Host != host {
+		t.Errorf("Expect health check host to be %s, but got %s", host, httpCheck.HttpHealthCheck.Host)
+	}
+
+	if httpCheck.HttpHealthCheck.Path != path {
+		t.Errorf("Expect health check path to be %s, but got %s", path, httpCheck.HttpHealthCheck.Path)
+	}
+
 }
 
 func mustParseDuration(dur string) time.Duration {

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -192,7 +192,7 @@ func (c *KubernetesConfigurator) generateClusters(config *envoyConfiguration) []
 
 	for _, cluster := range config.Clusters {
 		addresses := makeAddresses(cluster.Hosts, c.upstreamPort)
-		cluster := makeCluster(cluster.Name, c.trustCA, cluster.HealthCheckPath, c.upstreamHealthCheck, cluster.Timeout, c.outlierPercentage, addresses)
+		cluster := makeCluster(*cluster, c.trustCA, c.upstreamHealthCheck, c.outlierPercentage, addresses)
 		clusters = append(clusters, cluster)
 	}
 

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -79,6 +79,7 @@ func (v *virtualHost) Equals(other *virtualHost) bool {
 
 type cluster struct {
 	Name            string
+	VirtualHost     string
 	HealthCheckPath string
 	Timeout         time.Duration
 	Hosts           []string
@@ -98,6 +99,10 @@ func (c *cluster) Equals(other *cluster) bool {
 	}
 
 	if c.Timeout != other.Timeout {
+		return false
+	}
+
+	if c.VirtualHost != other.VirtualHost {
 		return false
 	}
 
@@ -158,6 +163,7 @@ func newEnvoyIngress(host string) *envoyIngress {
 		},
 		cluster: &cluster{
 			Name:            clusterName,
+			VirtualHost:     host,
 			Hosts:           []string{},
 			Timeout:         (30 * time.Second),
 			HealthCheckPath: "",

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -13,6 +13,10 @@ func TestVirtualHostEquality(t *testing.T) {
 	a := &virtualHost{Host: "foo"}
 	b := &virtualHost{Host: "foo"}
 
+	if a.Equals(nil) {
+		t.Error("virtual host is equal nix, expected not to be equal")
+	}
+
 	if !a.Equals(b) {
 		t.Error()
 	}
@@ -41,6 +45,10 @@ func TestClusterEquality(t *testing.T) {
 		t.Error()
 	}
 
+	if a.Equals(nil) {
+		t.Error("cluster is equals nil, expect not to be equal")
+	}
+
 	c := &cluster{Name: "bar", Hosts: []string{"host1", "host2"}}
 	if a.Equals(c) {
 		t.Error("clusters have different names, expected not to be equal")
@@ -64,6 +72,16 @@ func TestClusterEquality(t *testing.T) {
 	g := &cluster{Name: "foo", Hosts: []string{"host1", "host2"}, Timeout: (5 * time.Second)}
 	if a.Equals(g) {
 		t.Error("clusters with different timeout values should not be equal")
+	}
+
+	h := &cluster{Name: "foo", VirtualHost: "bar"}
+	if a.Equals(h) {
+		t.Error("cluster virtualHosts are different, shouldn't be equal")
+	}
+
+	i := &cluster{Name: "foo", HealthCheckPath: "bar"}
+	if a.Equals(i) {
+		t.Error("cluster virtualHosts are different, shouldn't be equal")
 	}
 }
 
@@ -163,6 +181,10 @@ func TestGeneratesForSingleIngress(t *testing.T) {
 
 	if c.VirtualHosts[0].UpstreamCluster != c.Clusters[0].Name {
 		t.Errorf("expected upstream cluster of vHost the same as the generated cluster, was %s and %s", c.VirtualHosts[0].UpstreamCluster, c.Clusters[0].Name)
+	}
+
+	if c.Clusters[0].VirtualHost != "foo.app.com" {
+		t.Errorf("expected upstream cluster vHost the same as the ingress vHost")
 	}
 }
 


### PR DESCRIPTION
Without the hostname the cluster ingress can not route the health check to the proper service. Thus I set the hostname in the HTTP health checker.

I'm not that happy with the strings.Replace() hack to get back the host name served by the cluster. 
What are your thoughts regarding refactoring the `pkg/envoy/envoyConfiguration` struct? Do you mind to explain the reasoning behind the VirtualHost/Clusters split?