### PR TITLE
Add --envoy-listener-ipv4-address flag to configure downstream listen IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The Yggdrasil-specific metrics which are available from the API are:
 --cert string                              certfile
 --config string                            config file
 --debug                                    Log at debug level
+--envoy-listener-ipv4-address string       IPv4 address by the envoy proxy to accept incoming connections (default 0.0.0.0)
 --envoy-port uint32                        port by the envoy proxy to accept incoming connections (default 10000)
 --health-address string                    yggdrasil health API listen address (default "0.0.0.0:8081")
 -h, --help                                 help for yggdrasil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ type config struct {
 	Certificates               []envoy.Certificate       `json:"certificates"`
 	TrustCA                    string                    `json:"trustCA"`
 	UpstreamPort               uint32                    `json:"upstreamPort"`
+	EnvoyListenerIpv4Address   string                    `json:"envoyListenerIpv4Address"`
 	EnvoyPort                  uint32                    `json:"envoyPort"`
 	MaxEjectionPercentage      uint32                    `json:"maxEjectionPercentage"`
 	HostSelectionRetryAttempts int64                     `json:"hostSelectionRetryAttempts"`
@@ -80,6 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVar(&kubeConfig, "kube-config", nil, "Path to kube config")
 	rootCmd.PersistentFlags().Bool("debug", false, "Log at debug level")
 	rootCmd.PersistentFlags().Uint32("upstream-port", 443, "port used to connect to the upstream ingresses")
+	rootCmd.PersistentFlags().String("envoy-listener-ipv4-address", "0.0.0.0", "IPv4 address by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Uint32("envoy-port", 10000, "port by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Int32("max-ejection-percentage", -1, "maximal percentage of hosts ejected via outlier detection. Set to >=0 to activate outlier detection in envoy.")
 	rootCmd.PersistentFlags().Int64("host-selection-retry-attempts", -1, "Number of host selection retry attempts. Set to value >=0 to enable")
@@ -96,6 +98,7 @@ func init() {
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
 	viper.BindPFlag("trustCA", rootCmd.PersistentFlags().Lookup("ca"))
 	viper.BindPFlag("upstreamPort", rootCmd.PersistentFlags().Lookup("upstream-port"))
+	viper.BindPFlag("envoyListenerIpv4Address", rootCmd.PersistentFlags().Lookup("envoy-listener-ipv4-address"))
 	viper.BindPFlag("envoyPort", rootCmd.PersistentFlags().Lookup("envoy-port"))
 	viper.BindPFlag("maxEjectionPercentage", rootCmd.PersistentFlags().Lookup("max-ejection-percentage"))
 	viper.BindPFlag("hostSelectionRetryAttempts", rootCmd.PersistentFlags().Lookup("host-selection-retry-attempts"))
@@ -186,6 +189,7 @@ func main(*cobra.Command, []string) error {
 		viper.GetString("trustCA"),
 		viper.GetStringSlice("ingressClasses"),
 		envoy.WithUpstreamPort(uint32(viper.GetInt32("upstreamPort"))),
+		envoy.WithEnvoyListenerIpv4Address(viper.GetString("envoyListenerIpv4Address")),
 		envoy.WithEnvoyPort(uint32(viper.GetInt32("envoyPort"))),
 		envoy.WithOutlierPercentage(viper.GetInt32("maxEjectionPercentage")),
 		envoy.WithHostSelectionRetryAttempts(viper.GetInt64("hostSelectionRetryAttempts")),

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -228,14 +228,14 @@ func makeFilterChain(certificate Certificate, virtualHosts []*route.VirtualHost)
 	}, nil
 }
 
-func makeListener(filterChains []*listener.FilterChain, envoyListenPort uint32) *listener.Listener {
+func makeListener(filterChains []*listener.FilterChain, envoyListenerIpv4Address string, envoyListenPort uint32) *listener.Listener {
 
 	listener := listener.Listener{
 		Name: "listener_0",
 		Address: &core.Address{
 			Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{
-					Address: "0.0.0.0",
+					Address: envoyListenerIpv4Address,
 					PortSpecifier: &core.SocketAddress_PortValue{
 						PortValue: envoyListenPort,
 					},

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -37,6 +37,7 @@ type KubernetesConfigurator struct {
 	trustCA                    string
 	upstreamPort               uint32
 	envoyListenPort            uint32
+	envoyListenerIpv4Address   string
 	outlierPercentage          int32
 	hostSelectionRetryAttempts int64
 	upstreamHealthCheck        UpstreamHealthCheck
@@ -135,7 +136,7 @@ func (c *KubernetesConfigurator) generateListeners(config *envoyConfiguration) [
 	} else {
 		filterChains = c.generateHTTPFilterChain(config)
 	}
-	return []tcache.Resource{makeListener(filterChains, c.envoyListenPort)}
+	return []tcache.Resource{makeListener(filterChains, c.envoyListenerIpv4Address, c.envoyListenPort)}
 }
 
 func (c *KubernetesConfigurator) generateHTTPFilterChain(config *envoyConfiguration) []*listener.FilterChain {

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -3,6 +3,13 @@ package envoy
 type option func(c *KubernetesConfigurator)
 
 // WithEnvoyPort configures the given envoy port into a KubernetesConfigurator
+func WithEnvoyListenerIpv4Address(address string) option {
+	return func(c *KubernetesConfigurator) {
+		c.envoyListenerIpv4Address = address
+	}
+}
+
+// WithEnvoyPort configures the given envoy port into a KubernetesConfigurator
 func WithEnvoyPort(port uint32) option {
 	return func(c *KubernetesConfigurator) {
 		c.envoyListenPort = port


### PR DESCRIPTION
This PR adds a `--envoy-listener-ipv4-address` flag that configures the downstream envoy listener IP, leaving it `0.0.0.0` by default if not provided.

No breaking change.

Closes https://github.com/uswitch/yggdrasil/issues/57