### PR TITLE
Add --use-remote-address flag to set X-Forwarded-For headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,5 @@ The Yggdrasil-specific metrics which are available from the API are:
 --upstream-healthcheck-timeout duration    timeout of the upstream healthchecks (default 5s)
 --upstream-healthcheck-unhealthy uint32    number of failed healthchecks before the backend is considered unhealthy (default 3)
 --upstream-port uint32                     port used to connect to the upstream ingresses (default 443)
+--use-remote-address                       populates the X-Forwarded-For header with the client address. Set to true when used as edge proxy - [documentation](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address) (default false)
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ type config struct {
 	MaxEjectionPercentage      uint32                    `json:"maxEjectionPercentage"`
 	HostSelectionRetryAttempts int64                     `json:"hostSelectionRetryAttempts"`
 	UpstreamHealthCheck        envoy.UpstreamHealthCheck `json:"upstreamHealthCheck"`
+	UseRemoteAddress           bool                      `json:"useRemoteAddress"`
 }
 
 // Hasher returns node ID as an ID
@@ -87,6 +88,7 @@ func init() {
 	rootCmd.PersistentFlags().Duration("upstream-healthcheck-timeout", 5*time.Second, "timeout of the upstream healthchecks")
 	rootCmd.PersistentFlags().Uint32("upstream-healthcheck-healthy", 3, "number of successful healthchecks before the backend is considered healthy")
 	rootCmd.PersistentFlags().Uint32("upstream-healthcheck-unhealthy", 3, "number of failed healthchecks before the backend is considered unhealthy")
+	rootCmd.PersistentFlags().Bool("use-remote-address", false, "populates the X-Forwarded-For header with the client address. Set to true when used as edge proxy")
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
@@ -103,6 +105,7 @@ func init() {
 	viper.BindPFlag("upstreamHealthCheck.timeout", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-timeout"))
 	viper.BindPFlag("upstreamHealthCheck.healthyThreshold", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-healthy"))
 	viper.BindPFlag("upstreamHealthCheck.unhealthyThreshold", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-unhealthy"))
+	viper.BindPFlag("useRemoteAddress", rootCmd.PersistentFlags().Lookup("use-remote-address"))
 }
 
 func initConfig() {
@@ -190,6 +193,7 @@ func main(*cobra.Command, []string) error {
 		envoy.WithOutlierPercentage(viper.GetInt32("maxEjectionPercentage")),
 		envoy.WithHostSelectionRetryAttempts(viper.GetInt64("hostSelectionRetryAttempts")),
 		envoy.WithUpstreamHealthCheck(c.UpstreamHealthCheck),
+		envoy.WithUseRemoteAddress(c.UseRemoteAddress),
 	)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, lister)
 

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -40,6 +40,7 @@ type KubernetesConfigurator struct {
 	outlierPercentage          int32
 	hostSelectionRetryAttempts int64
 	upstreamHealthCheck        UpstreamHealthCheck
+	useRemoteAddress           bool
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string
@@ -144,7 +145,7 @@ func (c *KubernetesConfigurator) generateHTTPFilterChain(config *envoyConfigurat
 		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts))
 	}
 
-	httpConnectionManager := makeConnectionManager(virtualHosts)
+	httpConnectionManager := c.makeConnectionManager(virtualHosts)
 	httpConfig, err := util.MessageToStruct(httpConnectionManager)
 	if err != nil {
 		log.Fatalf("failed to convert virtualHost to envoy control plane struct: %s", err)
@@ -187,7 +188,7 @@ func (c *KubernetesConfigurator) generateTLSFilterChains(config *envoyConfigurat
 			continue
 		}
 
-		filterChain, err := makeFilterChain(certificate, virtualHosts)
+		filterChain, err := c.makeFilterChain(certificate, virtualHosts)
 		if err != nil {
 			log.Printf("Error making filter chain: %v", err)
 		}

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -36,3 +36,10 @@ func WithUpstreamHealthCheck(config UpstreamHealthCheck) option {
 		c.upstreamHealthCheck = config
 	}
 }
+
+// WithUseRemoteAddress configures the useRemoteAddress option into the KubernetesConfigurator
+func WithUseRemoteAddress(useRemoteAddress bool) option {
+	return func(c *KubernetesConfigurator) {
+		c.useRemoteAddress = useRemoteAddress
+	}
+}

--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -26,7 +26,7 @@ func (i *IngressAggregator) Events() chan interface{} {
 }
 
 //Run starts all the ingress informers. Will block until all controllers
-//have sycned. Shouldn't be called in go routine
+//have synced. Shouldn't be called in go routine
 func (i *IngressAggregator) Run(ctx context.Context) error {
 	for _, c := range i.controllers {
 		logrus.Debugf("starting cache controller: %+v", c)


### PR DESCRIPTION
Hi, this adds a `--use-remote-address` flag that configures the [use_remote_address](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-use-remote-address) envoy connection manager option so that the `X-Forwarded-For` header is populated with the client IP.  
This is necessary when using envoy as edge proxy nodes to forward the correct headers to the upstreams.

This brings no breaking change.

Thanks!