### PR TITLE
SEC-516 Remove 'master' restriction for tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,4 +38,3 @@ pipeline:
       - ${DRONE_TAG}
     when:
       event: tag
-      branch: master


### PR DESCRIPTION
This fixes an issue with Drone not picking up the branch from the deployment