### PR TITLE
Add flag and annotation to configure retry-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Yggdrasil allows for some customisation of the route and cluster config per Ingr
 |--------------------------------------------------------------|----------|
 | [yggdrasil.uswitch.com/healthcheck-path](#health-check-path) | string   |
 | [yggdrasil.uswitch.com/timeout](#timeout)                    | duration |
+| [yggdrasil.uswitch.com/retry-on](#retries)                   | string   |
 
 ### Health Check Path
 Specifies a path to configure a [HTTP health check](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/core/v3/health_check.proto#config-core-v3-healthcheck-httphealthcheck) to. Envoy will not route to clusters that fail health checks.
@@ -89,6 +90,9 @@ Allows for adjusting the timeout in envoy. Currently this will set the following
 * [config.route.v3.RetryPolicy.PerTryTimeout](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-per-try-timeout)
 * [config.cluster.v3.Cluster.ConnectTimeout](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout)
 
+### Retries
+Allows overwriting the default retry policy's [config.route.v3.RetryPolicy.RetryOn](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-retry-on) set by the `--retry-on` flag (default 5xx). Accepts a comma-separated list of retry-on policies.
+
 ### Example
 Below is an example of an ingress with some of the annotations specified
 
@@ -101,6 +105,7 @@ metadata:
   annotations:
     yggdrasil.uswitch.com/healthcheck-path: /healthz
     yggdrasil.uswitch.com/timeout: 30s
+    yggdrasil.uswitch.com/retry-on: gateway-error,connect-failure
 spec:
   rules:
   - host: example.com
@@ -170,6 +175,7 @@ The Yggdrasil-specific metrics which are available from the API are:
 --health-address string                       yggdrasil health API listen address (default "0.0.0.0:8081")
 --help                                        help for yggdrasil
 --host-selection-retry-attempts int           Number of host selection retry attempts. Set to value >=0 to enable (default -1)
+--retry-on                                    Default comma-separated list of retry policies (default 5xx)
 --http-ext-authz-allow-partial-message        When this field is true, Envoy will buffer the message until max_request_bytes is reached (default true)
 --http-ext-authz-cluster string               The name of the upstream gRPC cluster
 --http-ext-authz-failure-mode-allow           Changes filters behaviour on errors (default true)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint32("envoy-port", 10000, "port by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Int32("max-ejection-percentage", -1, "maximal percentage of hosts ejected via outlier detection. Set to >=0 to activate outlier detection in envoy.")
 	rootCmd.PersistentFlags().Int64("host-selection-retry-attempts", -1, "Number of host selection retry attempts. Set to value >=0 to enable")
+	rootCmd.PersistentFlags().String("retry-on", "5xx", "default comma-separated list of retry policies")
 	rootCmd.PersistentFlags().Duration("upstream-healthcheck-interval", 10*time.Second, "duration of the upstream health check interval")
 	rootCmd.PersistentFlags().Duration("upstream-healthcheck-timeout", 5*time.Second, "timeout of the upstream healthchecks")
 	rootCmd.PersistentFlags().Uint32("upstream-healthcheck-healthy", 3, "number of successful healthchecks before the backend is considered healthy")
@@ -116,6 +117,7 @@ func init() {
 	viper.BindPFlag("envoyPort", rootCmd.PersistentFlags().Lookup("envoy-port"))
 	viper.BindPFlag("maxEjectionPercentage", rootCmd.PersistentFlags().Lookup("max-ejection-percentage"))
 	viper.BindPFlag("hostSelectionRetryAttempts", rootCmd.PersistentFlags().Lookup("host-selection-retry-attempts"))
+	viper.BindPFlag("retryOn", rootCmd.PersistentFlags().Lookup("retry-on"))
 	viper.BindPFlag("upstreamHealthCheck.interval", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-interval"))
 	viper.BindPFlag("upstreamHealthCheck.timeout", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-timeout"))
 	viper.BindPFlag("upstreamHealthCheck.healthyThreshold", rootCmd.PersistentFlags().Lookup("upstream-healthcheck-healthy"))
@@ -151,6 +153,10 @@ func main(*cobra.Command, []string) error {
 	err := viper.Unmarshal(&c)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling viper config: %s", err)
+	}
+
+	if !envoy.ValidateEnvoyRetryOn(viper.GetString("retryOn")) {
+		return fmt.Errorf("invalid retry-on parameter: %s", viper.GetString("retryOn"))
 	}
 
 	if viper.Get("debug") == true {
@@ -222,6 +228,7 @@ func main(*cobra.Command, []string) error {
 		envoy.WithUseRemoteAddress(c.UseRemoteAddress),
 		envoy.WithHttpExtAuthzCluster(c.HttpExtAuthz),
 		envoy.WithHttpGrpcLogger(c.HttpGrpcLogger),
+		envoy.WithDefaultRetryOn(viper.GetString("retryOn")),
 	)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, lister)
 

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -3,6 +3,7 @@ package envoy
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	cal "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	v3cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -21,13 +22,15 @@ import (
 	any "github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var (
-	jsonFormat *structpb.Struct
+	jsonFormat            *structpb.Struct
+	allowedRetryOnsRegexp string
 )
 
 func init() {
@@ -56,9 +59,18 @@ func init() {
 		log.Fatal(err)
 	}
 	jsonFormat = b.GetStructValue()
+
+	allowedRetryOns := "5xx|gateway-error|reset|connect-failure|envoy-ratelimited|retriable-4xx|refused-stream|retriable-status-codes|retriable-headers|http3-post-connect-failure"
+	allowedRetryOnsRegexp = fmt.Sprintf("^((%s)(,(%s))*)?$", allowedRetryOns, allowedRetryOns)
 }
 
-func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.VirtualHost {
+func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64, defaultRetryOn string) *route.VirtualHost {
+	var retryOn string
+	if vhost.RetryOn != "" {
+		retryOn = vhost.RetryOn
+	} else {
+		retryOn = defaultRetryOn
+	}
 
 	action := &route.Route_Route{
 		Route: &route.RouteAction{
@@ -67,7 +79,7 @@ func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64) *route.Virtu
 				Cluster: vhost.UpstreamCluster,
 			},
 			RetryPolicy: &route.RetryPolicy{
-				RetryOn:       "5xx",
+				RetryOn:       retryOn,
 				PerTryTimeout: &duration.Duration{Seconds: int64(vhost.PerTryTimeout.Seconds())},
 			},
 		},
@@ -438,4 +450,13 @@ func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPer
 	}
 
 	return cluster
+}
+
+func ValidateEnvoyRetryOn(retryOn string) bool {
+	matched, err := regexp.MatchString(allowedRetryOnsRegexp, retryOn)
+	if err != nil {
+		logrus.Debugf("error parsing regexp: %s", err)
+		return false
+	}
+	return matched
 }

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -74,10 +74,8 @@ func init() {
 }
 
 func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64, defaultRetryOn string) *route.VirtualHost {
-	var retryOn string
-	if vhost.RetryOn != "" {
-		retryOn = vhost.RetryOn
-	} else {
+	retryOn := vhost.RetryOn
+	if retryOn == "" {
 		retryOn = defaultRetryOn
 	}
 

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -60,6 +60,7 @@ type KubernetesConfigurator struct {
 	useRemoteAddress           bool
 	httpExtAuthz               HttpExtAuthz
 	httpGrpcLogger             HttpGrpcLogger
+	defaultRetryOn             string
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string
@@ -161,7 +162,7 @@ func (c *KubernetesConfigurator) generateListeners(config *envoyConfiguration) [
 func (c *KubernetesConfigurator) generateHTTPFilterChain(config *envoyConfiguration) []*listener.FilterChain {
 	virtualHosts := []*route.VirtualHost{}
 	for _, virtualHost := range config.VirtualHosts {
-		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts))
+		virtualHosts = append(virtualHosts, makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts, c.defaultRetryOn))
 	}
 
 	httpConnectionManager := c.makeConnectionManager(virtualHosts)
@@ -194,7 +195,7 @@ func (c *KubernetesConfigurator) generateTLSFilterChains(config *envoyConfigurat
 			log.Printf("Error matching certificate for '%s': %v", virtualHost.Host, err)
 		} else {
 			for _, idx := range certificateIndicies {
-				virtualHostsForCertificates[idx] = append(virtualHostsForCertificates[idx], makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts))
+				virtualHostsForCertificates[idx] = append(virtualHostsForCertificates[idx], makeVirtualHost(virtualHost, c.hostSelectionRetryAttempts, c.defaultRetryOn))
 			}
 		}
 	}

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -2,7 +2,7 @@ package envoy
 
 type option func(c *KubernetesConfigurator)
 
-// WithEnvoyPort configures the given envoy port into a KubernetesConfigurator
+// WithEWithEnvoyListenerIpv4AddressnvoyPort configures envoy IPv4 listen address into a KubernetesConfigurator
 func WithEnvoyListenerIpv4Address(address string) option {
 	return func(c *KubernetesConfigurator) {
 		c.envoyListenerIpv4Address = address
@@ -62,5 +62,12 @@ func WithHttpExtAuthzCluster(httpExtAuthz HttpExtAuthz) option {
 func WithHttpGrpcLogger(httpGrpcLogger HttpGrpcLogger) option {
 	return func(c *KubernetesConfigurator) {
 		c.httpGrpcLogger = httpGrpcLogger
+	}
+}
+
+// WithDefaultRetryOn configures the default retry policy
+func WithDefaultRetryOn(defaultRetryOn string) option {
+	return func(c *KubernetesConfigurator) {
+		c.defaultRetryOn = defaultRetryOn
 	}
 }


### PR DESCRIPTION
This feature adds a flag to configure retry-on policies, also overwritable by the `yggdrasil.uswitch.com/retry-on` ingress annotation.  

No breaking change, the default retry policy stays `5xx`.

Thanks!