### PR TITLE
AIRSHIP-2080 Fix names for config properties

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -167,8 +167,8 @@ func makeGrpcLoggerConfig(cfg HttpGrpcLogger) *gal.HttpGrpcAccessLogConfig {
 			},
 			TransportApiVersion: core.ApiVersion_V3,
 		},
-		AdditionalRequestHeadersToLog:  cfg.AdditionalRequestHeaders,
-		AdditionalResponseHeadersToLog: cfg.AdditionalResponseHeaders,
+		AdditionalRequestHeadersToLog:  cfg.RequestHeaders,
+		AdditionalResponseHeadersToLog: cfg.ResponseHeaders,
 	}
 }
 

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -39,11 +39,11 @@ type HttpExtAuthz struct {
 }
 
 type HttpGrpcLogger struct {
-	Name                      string        `json:"name"`
-	Cluster                   string        `json:"cluster"`
-	Timeout                   time.Duration `json:"timeout"`
-	AdditionalRequestHeaders  []string      `json:"additionalRequestHeaders"`
-	AdditionalResponseHeaders []string      `json:"additionalResponseHeaders"`
+	Name            string        `json:"name"`
+	Cluster         string        `json:"cluster"`
+	Timeout         time.Duration `json:"timeout"`
+	RequestHeaders  []string      `json:"requestHeaders"`
+	ResponseHeaders []string      `json:"responseHeaders"`
 }
 
 //KubernetesConfigurator takes a given Ingress Class and lister to find only ingresses of that class


### PR DESCRIPTION
The HTTP GRPC Access logger's request and response header fields were incorrectly labeled causing the config to never reach the necessary fields.

This aligns the names to all just be request/response Headers.