### PR TITLE
Add configurable listener ALPN protocols to enable downstream http2

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ type config struct {
 	UseRemoteAddress           bool                      `json:"useRemoteAddress"`
 	HttpExtAuthz               envoy.HttpExtAuthz        `json:"httpExtAuthz"`
 	HttpGrpcLogger             envoy.HttpGrpcLogger      `json:"httpGrpcLogger"`
+	AlpnProtocols              []string                  `json:"alpnProtocols"`
 }
 
 // Hasher returns node ID as an ID
@@ -104,6 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("http-ext-authz-allow-partial-message", true, "When this field is true, Envoy will buffer the message until max_request_bytes is reached")
 	rootCmd.PersistentFlags().Bool("http-ext-authz-pack-as-bytes", false, "When this field is true, Envoy will send the body as raw bytes.")
 	rootCmd.PersistentFlags().Bool("http-ext-authz-failure-mode-allow", true, "Changes filters behaviour on errors")
+	rootCmd.PersistentFlags().StringSlice("alpn-protocols", []string{}, "exposed listener ALPN protocols")
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
@@ -134,6 +136,7 @@ func init() {
 	viper.BindPFlag("httpExtAuthz.allowPartialMessage", rootCmd.PersistentFlags().Lookup("http-ext-authz-allow-partial-message"))
 	viper.BindPFlag("httpExtAuthz.packAsBytes", rootCmd.PersistentFlags().Lookup("http-ext-authz-pack-as-bytes"))
 	viper.BindPFlag("httpExtAuthz.FailureModeAllow", rootCmd.PersistentFlags().Lookup("http-ext-authz-failure-mode-allow"))
+	viper.BindPFlag("alpnProtocols", rootCmd.PersistentFlags().Lookup("alpn-protocols"))
 }
 
 func initConfig() {
@@ -230,6 +233,7 @@ func main(*cobra.Command, []string) error {
 		envoy.WithHttpExtAuthzCluster(c.HttpExtAuthz),
 		envoy.WithHttpGrpcLogger(c.HttpGrpcLogger),
 		envoy.WithDefaultRetryOn(viper.GetString("retryOn")),
+		envoy.WithAlpnProtocols(viper.GetStringSlice("alpnProtocols")),
 	)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, aggregator)
 

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -283,6 +283,7 @@ func (c *KubernetesConfigurator) makeFilterChain(certificate Certificate, virtua
 
 	tls := &auth.DownstreamTlsContext{}
 	tls.CommonTlsContext = &auth.CommonTlsContext{
+		AlpnProtocols: c.alpnProtocols,
 		TlsCertificates: []*auth.TlsCertificate{
 			{
 				CertificateChain: &core.DataSource{

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -62,6 +62,7 @@ type KubernetesConfigurator struct {
 	httpExtAuthz               HttpExtAuthz
 	httpGrpcLogger             HttpGrpcLogger
 	defaultRetryOn             string
+	alpnProtocols              []string
 
 	previousConfig  *envoyConfiguration
 	listenerVersion string

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -71,3 +71,10 @@ func WithDefaultRetryOn(defaultRetryOn string) option {
 		c.defaultRetryOn = defaultRetryOn
 	}
 }
+
+// WithAlpnProtocols configures the the exposed listener ALPN protocols
+func WithAlpnProtocols(alpnProtocols []string) option {
+	return func(c *KubernetesConfigurator) {
+		c.alpnProtocols = alpnProtocols
+	}
+}


### PR DESCRIPTION
No breaking change, listener offers no ALPN protocol by default.