### PR TITLE
Configure TypedConfig for filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ SOURCES := $(shell find . -iname '*.go')
 
 .PHONY: test clean all
 
-all: build-darwin build-linux
+all: build-darwin $(BIN_LINUX)
 
 build-darwin: $(SOURCES)
 	GOARCH=$(ARCH) GOOS=darwin go build -o $(BIN_DARWIN)
 
-build-linux: $(SOURCES)
+$(BIN_LINUX): $(SOURCES)
 	GOARCH=$(ARCH) GOOS=linux CGO_ENABLED=0 go build -o $(BIN_LINUX)
 
 test: $(SOURCES)
@@ -22,7 +22,7 @@ bench: $(SOURCES)
 	go test -run=XX -bench=. $(shell go list ./... | grep -v /vendor)
 
 docker: Dockerfile $(BIN_LINUX)
-	docker image build -t quay.io/uswitch/yggdrasil:devel .
+	docker image build -t registry.airship.rvu.cloud/cloud/yggdrasil:devel .
 
 clean:
 	rm -rf bin/

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ BIN_DARWIN = $(BIN)-darwin-$(ARCH)
 
 SOURCES := $(shell find . -iname '*.go')
 
-.PHONY: test clean all
+.PHONY: test clean all build-linux
 
 all: build-darwin $(BIN_LINUX)
 
 build-darwin: $(SOURCES)
 	GOARCH=$(ARCH) GOOS=darwin go build -o $(BIN_DARWIN)
+
+build-linux: $(BIN_LINUX)
 
 $(BIN_LINUX): $(SOURCES)
 	GOARCH=$(ARCH) GOOS=linux CGO_ENABLED=0 go build -o $(BIN_LINUX)

--- a/pkg/envoy/http_filters.go
+++ b/pkg/envoy/http_filters.go
@@ -1,7 +1,11 @@
 package envoy
 
 import (
+	"fmt"
+
+	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	types "github.com/golang/protobuf/ptypes"
 )
 
 type httpFilterBuilder struct {
@@ -13,7 +17,16 @@ func (b *httpFilterBuilder) Add(filter *hcm.HttpFilter) *httpFilterBuilder {
 	return b
 }
 
-func (b *httpFilterBuilder) Filters() []*hcm.HttpFilter {
-	b.Add(&hcm.HttpFilter{Name: "envoy.filters.http.router"})
-	return b.filters
+func (b *httpFilterBuilder) Filters() ([]*hcm.HttpFilter, error) {
+	router := &router.Router{}
+
+	anyRouter, err := types.MarshalAny(router)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal router config struct to typed struct: %s", err)
+	}
+	b.Add(&hcm.HttpFilter{
+		Name:       "envoy.filters.http.router",
+		ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: anyRouter},
+	})
+	return b.filters, nil
 }


### PR DESCRIPTION
Configure TypedConfig where it is now required by envoy
Skip unnecessary calls to `util.MessageToStruct()` which was resulting in type `google.protobuf.Struct` being set throughout the envoy config