### PR TITLE
AIRSHIP-2978 Customisable Access Log formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The Yggdrasil-specific metrics which are available from the API are:
 --ca string                                   trustedCA
 --cert string                                 certfile
 --config string                               config file
+--config-dump                                 Enable config dump endpoint at /configdump on the health-address HTTP server
 --debug                                       Log at debug level
 --envoy-listener-ipv4-address string          IPv4 address by the envoy proxy to accept incoming connections (default "0.0.0.0")
 --envoy-port uint32                           port by the envoy proxy to accept incoming connections (default 10000)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("ingress-classes", nil, "Ingress classes to watch")
 	rootCmd.PersistentFlags().StringArrayVar(&kubeConfig, "kube-config", nil, "Path to kube config")
 	rootCmd.PersistentFlags().Bool("debug", false, "Log at debug level")
-	rootCmd.PersistentFlags().Bool("config-dump", false, "Enabled config dump endpoint")
+	rootCmd.PersistentFlags().Bool("config-dump", false, "Enable config dump endpoint at /configdump on the health-address HTTP server")
 	rootCmd.PersistentFlags().Uint32("upstream-port", 443, "port used to connect to the upstream ingresses")
 	rootCmd.PersistentFlags().String("envoy-listener-ipv4-address", "0.0.0.0", "IPv4 address by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Uint32("envoy-port", 10000, "port by the envoy proxy to accept incoming connections")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ type config struct {
 	UseRemoteAddress           bool                      `json:"useRemoteAddress"`
 	HttpExtAuthz               envoy.HttpExtAuthz        `json:"httpExtAuthz"`
 	HttpGrpcLogger             envoy.HttpGrpcLogger      `json:"httpGrpcLogger"`
+	AccessLogger               envoy.AccessLogger        `json:"accessLogger"`
 }
 
 // Hasher returns node ID as an ID
@@ -62,7 +63,7 @@ var rootCmd = &cobra.Command{
 	RunE:  main,
 }
 
-//Execute runs the function
+// Execute runs the function
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
@@ -104,6 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("http-ext-authz-allow-partial-message", true, "When this field is true, Envoy will buffer the message until max_request_bytes is reached")
 	rootCmd.PersistentFlags().Bool("http-ext-authz-pack-as-bytes", false, "When this field is true, Envoy will send the body as raw bytes.")
 	rootCmd.PersistentFlags().Bool("http-ext-authz-failure-mode-allow", true, "Changes filters behaviour on errors")
+
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
@@ -230,6 +232,7 @@ func main(*cobra.Command, []string) error {
 		envoy.WithHttpExtAuthzCluster(c.HttpExtAuthz),
 		envoy.WithHttpGrpcLogger(c.HttpGrpcLogger),
 		envoy.WithDefaultRetryOn(viper.GetString("retryOn")),
+		envoy.WithAccessLog(c.AccessLogger),
 	)
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, aggregator)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("ingress-classes", nil, "Ingress classes to watch")
 	rootCmd.PersistentFlags().StringArrayVar(&kubeConfig, "kube-config", nil, "Path to kube config")
 	rootCmd.PersistentFlags().Bool("debug", false, "Log at debug level")
+	rootCmd.PersistentFlags().Bool("config-dump", false, "Enabled config dump endpoint")
 	rootCmd.PersistentFlags().Uint32("upstream-port", 443, "port used to connect to the upstream ingresses")
 	rootCmd.PersistentFlags().String("envoy-listener-ipv4-address", "0.0.0.0", "IPv4 address by the envoy proxy to accept incoming connections")
 	rootCmd.PersistentFlags().Uint32("envoy-port", 10000, "port by the envoy proxy to accept incoming connections")
@@ -107,6 +108,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("http-ext-authz-failure-mode-allow", true, "Changes filters behaviour on errors")
 
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	viper.BindPFlag("configDump", rootCmd.PersistentFlags().Lookup("config-dump"))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
 	viper.BindPFlag("nodeName", rootCmd.PersistentFlags().Lookup("node-name"))
@@ -240,7 +242,7 @@ func main(*cobra.Command, []string) error {
 	go aggregator.Run()
 
 	envoyServer := server.NewServer(ctx, envoyCache, &callbacks{})
-	go runEnvoyServer(envoyServer, viper.GetString("address"), viper.GetString("healthAddress"), ctx.Done())
+	go runEnvoyServer(envoyServer, snapshotter, viper.GetBool("configDump"), viper.GetString("address"), viper.GetString("healthAddress"), ctx.Done())
 
 	<-stopCh
 	return nil

--- a/docs/ACCESSLOG.md
+++ b/docs/ACCESSLOG.md
@@ -1,0 +1,35 @@
+# Access Log
+
+The Access log format is configurable via the Yggdrasil config file only. It is defined as a json object as follows:
+
+```json
+{
+    "accessLogger": {
+        "format": {
+            "start_time":                "%START_TIME(%s.%3f)%",
+            "bytes_received":            "%BYTES_RECEIVED%",
+            "protocol":                  "%PROTOCOL%",
+            "response_code":             "%RESPONSE_CODE%",
+            "bytes_sent":                "%BYTES_SENT%",
+            "duration":                  "%DURATION%",
+            "response_flags":            "%RESPONSE_FLAGS%",
+            "upstream_host":             "%UPSTREAM_HOST%",
+            "upstream_cluster":          "%UPSTREAM_CLUSTER%",
+            "upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
+            "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
+            "downstream_local_address":  "%DOWNSTREAM_LOCAL_ADDRESS%",
+            "request_method":            "%REQ(:METHOD)%",
+            "request_path":              "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+            "upstream_service_time":     "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
+            "forwarded_for":             "%REQ(X-FORWARDED-FOR)%",
+            "user_agent":                "%REQ(USER-AGENT)%",
+            "request_id":                "%REQ(X-REQUEST-ID)%"
+        }
+    }
+}
+
+```
+
+The config above would be the same as the default access logger config shipped with Yggdasil. Thus if no format is provided this will be the format used.
+
+The access log is written to `/var/log/envoy/access.log` which is not currently configurable.

--- a/docs/ACCESSLOG.md
+++ b/docs/ACCESSLOG.md
@@ -32,4 +32,6 @@ The Access log format is configurable via the Yggdrasil config file only. It is 
 
 The config above would be the same as the default access logger config shipped with Yggdasil. Thus if no format is provided this will be the format used.
 
+[See Envoy docs for more on access log formats](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-default-format)
+
 The access log is written to `/var/log/envoy/access.log` which is not currently configurable.

--- a/docs/ACCESSLOG.md
+++ b/docs/ACCESSLOG.md
@@ -6,24 +6,24 @@ The Access log format is configurable via the Yggdrasil config file only. It is 
 {
     "accessLogger": {
         "format": {
-            "start_time":                "%START_TIME(%s.%3f)%",
             "bytes_received":            "%BYTES_RECEIVED%",
-            "protocol":                  "%PROTOCOL%",
-            "response_code":             "%RESPONSE_CODE%",
             "bytes_sent":                "%BYTES_SENT%",
-            "duration":                  "%DURATION%",
-            "response_flags":            "%RESPONSE_FLAGS%",
-            "upstream_host":             "%UPSTREAM_HOST%",
-            "upstream_cluster":          "%UPSTREAM_CLUSTER%",
-            "upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
-            "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
             "downstream_local_address":  "%DOWNSTREAM_LOCAL_ADDRESS%",
+            "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
+            "duration":                  "%DURATION%",
+            "forwarded_for":             "%REQ(X-FORWARDED-FOR)%",
+            "protocol":                  "%PROTOCOL%",
+            "request_id":                "%REQ(X-REQUEST-ID)%",
             "request_method":            "%REQ(:METHOD)%",
             "request_path":              "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+            "response_code":             "%RESPONSE_CODE%",
+            "response_flags":            "%RESPONSE_FLAGS%",
+            "start_time":                "%START_TIME(%s.%3f)%",
+            "upstream_cluster":          "%UPSTREAM_CLUSTER%",
+            "upstream_host":             "%UPSTREAM_HOST%",
+            "upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
             "upstream_service_time":     "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
-            "forwarded_for":             "%REQ(X-FORWARDED-FOR)%",
-            "user_agent":                "%REQ(USER-AGENT)%",
-            "request_id":                "%REQ(X-REQUEST-ID)%"
+            "user_agent":                "%REQ(USER-AGENT)%"
         }
     }
 }

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -34,24 +34,24 @@ var (
 	allowedRetryOns map[string]bool
 
 	DefaultAccessLogFormat = map[string]interface{}{
-		"start_time":                "%START_TIME(%s.%3f)%",
 		"bytes_received":            "%BYTES_RECEIVED%",
-		"protocol":                  "%PROTOCOL%",
-		"response_code":             "%RESPONSE_CODE%",
 		"bytes_sent":                "%BYTES_SENT%",
-		"duration":                  "%DURATION%",
-		"response_flags":            "%RESPONSE_FLAGS%",
-		"upstream_host":             "%UPSTREAM_HOST%",
-		"upstream_cluster":          "%UPSTREAM_CLUSTER%",
-		"upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
-		"downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
 		"downstream_local_address":  "%DOWNSTREAM_LOCAL_ADDRESS%",
+		"downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
+		"duration":                  "%DURATION%",
+		"forwarded_for":             "%REQ(X-FORWARDED-FOR)%",
+		"protocol":                  "%PROTOCOL%",
+		"request_id":                "%REQ(X-REQUEST-ID)%",
 		"request_method":            "%REQ(:METHOD)%",
 		"request_path":              "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+		"response_code":             "%RESPONSE_CODE%",
+		"response_flags":            "%RESPONSE_FLAGS%",
+		"start_time":                "%START_TIME(%s.%3f)%",
+		"upstream_cluster":          "%UPSTREAM_CLUSTER%",
+		"upstream_host":             "%UPSTREAM_HOST%",
+		"upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
 		"upstream_service_time":     "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
-		"forwarded_for":             "%REQ(X-FORWARDED-FOR)%",
 		"user_agent":                "%REQ(USER-AGENT)%",
-		"request_id":                "%REQ(X-REQUEST-ID)%",
 	}
 )
 

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -100,13 +100,6 @@ func TestAccessLoggerConfig(t *testing.T) {
 	}
 }
 
-func TestAccessLoggerDefault(t *testing.T) {
-	_ = AccessLogger{
-		Format: map[string]interface{}{},
-	}
-
-}
-
 func mustParseDuration(dur string) time.Duration {
 	d, err := time.ParseDuration(dur)
 	if err != nil {

--- a/pkg/envoy/config_dump.go
+++ b/pkg/envoy/config_dump.go
@@ -1,0 +1,26 @@
+package envoy
+
+import (
+	types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+type EnvoySnapshot struct {
+	Listeners map[string]types.Resource
+	Clusters  map[string]types.Resource
+}
+
+func (s *Snapshotter) ConfigDump() (EnvoySnapshot, error) {
+	snapshot, err := s.CurrentSnapshot()
+	if err != nil {
+		return EnvoySnapshot{}, err
+	}
+
+	listeners := snapshot.GetResources(resource.ListenerType)
+	clusters := snapshot.GetResources(resource.ClusterType)
+
+	return EnvoySnapshot{
+		Listeners: listeners,
+		Clusters:  clusters,
+	}, nil
+}

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -11,7 +11,8 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tcache "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	types "github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/uswitch/yggdrasil/pkg/k8s"
 )
 
@@ -186,7 +187,7 @@ func (c *KubernetesConfigurator) generateHTTPFilterChain(config *envoyConfigurat
 	if err != nil {
 		return nil, err
 	}
-	anyHttpConfig, err := types.MarshalAny(httpConnectionManager)
+	anyHttpConfig, err := anypb.New(httpConnectionManager)
 	if err != nil {
 		log.Fatalf("failed to marshal HTTP config struct to typed struct: %s", err)
 	}

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -45,7 +45,11 @@ type HttpGrpcLogger struct {
 	ResponseHeaders []string      `json:"responseHeaders"`
 }
 
-//KubernetesConfigurator takes a given Ingress Class and lister to find only ingresses of that class
+type AccessLogger struct {
+	Format map[string]interface{} `json:"format"`
+}
+
+// KubernetesConfigurator takes a given Ingress Class and lister to find only ingresses of that class
 type KubernetesConfigurator struct {
 	ingressClasses             []string
 	nodeID                     string
@@ -60,6 +64,7 @@ type KubernetesConfigurator struct {
 	useRemoteAddress           bool
 	httpExtAuthz               HttpExtAuthz
 	httpGrpcLogger             HttpGrpcLogger
+	accessLogger               AccessLogger
 	defaultRetryOn             string
 
 	previousConfig  *envoyConfiguration
@@ -68,7 +73,7 @@ type KubernetesConfigurator struct {
 	sync.Mutex
 }
 
-//NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
+// NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
 func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, options ...option) *KubernetesConfigurator {
 	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, trustCA: ca}
 	for _, opt := range options {
@@ -77,7 +82,7 @@ func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca str
 	return c
 }
 
-//Generate creates a new snapshot
+// Generate creates a new snapshot
 func (c *KubernetesConfigurator) Generate(ingresses []*k8s.Ingress) (cache.Snapshot, error) {
 	c.Lock()
 	defer c.Unlock()
@@ -109,7 +114,7 @@ func (c *KubernetesConfigurator) Generate(ingresses []*k8s.Ingress) (cache.Snaps
 	return snap, nil
 }
 
-//NodeID returns the NodeID
+// NodeID returns the NodeID
 func (c *KubernetesConfigurator) NodeID() string {
 	return c.nodeID
 

--- a/pkg/envoy/options.go
+++ b/pkg/envoy/options.go
@@ -71,3 +71,10 @@ func WithDefaultRetryOn(defaultRetryOn string) option {
 		c.defaultRetryOn = defaultRetryOn
 	}
 }
+
+// WithAccessLog configures the access log formats
+func WithAccessLog(accessLogger AccessLogger) option {
+	return func(c *KubernetesConfigurator) {
+		c.accessLogger = accessLogger
+	}
+}


### PR DESCRIPTION
### Access Log format customisation
Make the default file access logger format configurable via the config file.

This will allow users to specify what they want to log in their access logs instead of just using the defaults we provide.

The default format remains unchanged though the fields were sorted in code to allow for easier grok'ing. It will be used if no format is provided in the config file.

### Config Dump endpoint
Also added an optional `/configdump` endpoint to the health HTTP server enabled with `--config-dump`.

This will dump the current Snapshot to JSON and can be useful to check what exactly Yggdrasil has going on without the constant `--debug` output or running an entire Envoy instance.