### PR TITLE
Feature : Add a new annotation to configure envoy upstream weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 bin/
 command
 testing
+ca/
+config/
+envoy/
+

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Yggdrasil allows for some customisation of the route and cluster config per Ingr
 |--------------------------------------------------------------|----------|
 | [yggdrasil.uswitch.com/healthcheck-path](#health-check-path) | string   |
 | [yggdrasil.uswitch.com/timeout](#timeout)                    | duration |
+| [yggdrasil.uswitch.com/weight](#weight)                      | uint32   |
 | [yggdrasil.uswitch.com/retry-on](#retries)                   | string   |
 
 ### Health Check Path
@@ -89,6 +90,9 @@ Allows for adjusting the timeout in envoy. Currently this will set the following
 * [config.route.v3.RouteAction.Timeout](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout)
 * [config.route.v3.RetryPolicy.PerTryTimeout](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-per-try-timeout)
 * [config.cluster.v3.Cluster.ConnectTimeout](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout)
+
+### Weight
+Allows for adjusting the [load balancer weights](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint_components.proto#config-endpoint-v3-lbendpoint) in envoy.
 
 ### Retries
 Allows overwriting the default retry policy's [config.route.v3.RetryPolicy.RetryOn](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-retry-on) set by the `--retry-on` flag (default 5xx). Accepts a comma-separated list of retry-on policies.
@@ -105,6 +109,7 @@ metadata:
   annotations:
     yggdrasil.uswitch.com/healthcheck-path: /healthz
     yggdrasil.uswitch.com/timeout: 30s
+    yggdrasil.uswitch.com/weight: "12"
     yggdrasil.uswitch.com/retry-on: gateway-error,connect-failure
 spec:
   rules:

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -400,14 +400,14 @@ func makeListener(filterChains []*listener.FilterChain, envoyListenerIpv4Address
 	return &listener, nil
 }
 
-func makeAddresses(addresses []string, upstreamPort uint32) []*core.Address {
+func makeAddresses(addresses []LBHost, upstreamPort uint32) []*core.Address {
 
 	envoyAddresses := []*core.Address{}
 	for _, address := range addresses {
 		envoyAddress := &core.Address{
 			Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{
-					Address: address,
+					Address: address.Host,
 					PortSpecifier: &core.SocketAddress_PortValue{
 						PortValue: upstreamPort,
 					},
@@ -475,7 +475,8 @@ func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPer
 
 	for idx, address := range addresses {
 		endpoints[idx] = &endpoint.LbEndpoint{
-			HostIdentifier: &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{Address: address}},
+			HostIdentifier:      &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{Address: address}},
+			LoadBalancingWeight: &wrappers.UInt32Value{Value: c.Hosts[idx].Weight},
 		}
 	}
 

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -273,7 +273,7 @@ func TestGeneratesForSingleIngress(t *testing.T) {
 	}
 
 	if c.Clusters[0].Hosts[0].Weight != 1 {
-		t.Errorf("expected cluster host's weight for 1, was %s", c.Clusters[0].Hosts[0].Weight)
+		t.Errorf("expected cluster host's weight for 1, was %d", c.Clusters[0].Hosts[0].Weight)
 	}
 
 	if c.VirtualHosts[0].UpstreamCluster != c.Clusters[0].Name {
@@ -309,10 +309,10 @@ func TestGeneratesForMultipleIngressSharingSpecHost(t *testing.T) {
 		t.Errorf("expected 2 host, was %d", len(c.Clusters[0].Hosts))
 	}
 	if c.Clusters[0].Hosts[0].Host != "foo.com" {
-		t.Errorf("expected cluster host for foo.com, was %s", c.Clusters[0].Hosts[0])
+		t.Errorf("expected cluster host for foo.com, was %s", c.Clusters[0].Hosts[0].Host)
 	}
 	if c.Clusters[0].Hosts[1].Host != "bar.com" {
-		t.Errorf("expected cluster host for bar.com, was %s", c.Clusters[0].Hosts[1])
+		t.Errorf("expected cluster host for bar.com, was %s", c.Clusters[0].Hosts[1].Host)
 	}
 
 	if c.VirtualHosts[0].UpstreamCluster != c.Clusters[0].Name {
@@ -345,7 +345,7 @@ func TestIngressWithIP(t *testing.T) {
 	ingress := newIngressIP("app.com", "127.0.0.1")
 	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{})
 	if c.Clusters[0].Hosts[0].Host != "127.0.0.1" {
-		t.Errorf("expected cluster host to be IP address, was %s", c.Clusters[0].Hosts[0])
+		t.Errorf("expected cluster host to be IP address, was %s", c.Clusters[0].Hosts[0].Host)
 	}
 }
 


### PR DESCRIPTION
Hello, 

The goal of this PR is to setup an annotation permitting to add a weight on upstream.

A weight of 0 means disable the endpoint.

This brings no breaking change as a weigh of 1 is by default

This feature has been in production in Numberly for two years, time for the PR :+1: 