### PR TITLE
Set minimum TLS version for downstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 bin/
 command
 testing
+ca/
+config/
+envoy/
+

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -329,6 +329,9 @@ func (c *KubernetesConfigurator) makeFilterChain(certificate Certificate, virtua
 				},
 			},
 		},
+		TlsParams: &auth.TlsParameters{
+			TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+		},
 	}
 
 	anyTls, err := anypb.New(tls)


### PR DESCRIPTION
Hi, this simply sets the minimum TLS version for downstream connections to 1.2 as per most of the security recommendations.

We understand this can be a breaking change, let me know if we should make this configurable.

Thanks :)