### PR TITLE
Configure internal_address_config on httpConnectionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ----
 Yggdrasil is an Envoy control plane that configures listeners and clusters based off Kubernetes ingresses from multiple Kube Clusters. This allows you to have an envoy cluster acting as a mutli-cluster loadbalancer for Kubernetes. This was something we needed as we wanted our apps to be highly available in the event of a cluster outage but did not want the solution to live inside of Kubernetes itself.
 
-`Note:` Currently we support versions 1.20.x to 1.26.x of Envoy.</br>
+`Note:` Currently we support versions 1.20.x to 1.29.x of Envoy.</br>
 `Note:` Yggdrasil now uses [Go modules](https://github.com/golang/go/wiki/Modules) to handle dependencies.
 
 ## Usage

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,6 +82,7 @@ func init() {
 	rootCmd.PersistentFlags().String("key", "", "keyfile")
 	rootCmd.PersistentFlags().String("ca", "", "trustedCA")
 	rootCmd.PersistentFlags().StringSlice("ingress-classes", nil, "Ingress classes to watch")
+	rootCmd.PersistentFlags().StringSlice("internal-cidr-ranges", []string{"192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"}, "CIDR ranges to treat as internal")
 	rootCmd.PersistentFlags().StringArrayVar(&kubeConfig, "kube-config", nil, "Path to kube config")
 	rootCmd.PersistentFlags().Bool("debug", false, "Log at debug level")
 	rootCmd.PersistentFlags().Bool("config-dump", false, "Enable config dump endpoint at /configdump on the health-address HTTP server")
@@ -115,6 +116,7 @@ func init() {
 	viper.BindPFlag("healthAddress", rootCmd.PersistentFlags().Lookup("health-address"))
 	viper.BindPFlag("nodeName", rootCmd.PersistentFlags().Lookup("node-name"))
 	viper.BindPFlag("ingressClasses", rootCmd.PersistentFlags().Lookup("ingress-classes"))
+	viper.BindPFlag("internalCidrRanges", rootCmd.PersistentFlags().Lookup("internal-cidr-ranges"))
 	viper.BindPFlag("cert", rootCmd.PersistentFlags().Lookup("cert"))
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
 	viper.BindPFlag("trustCA", rootCmd.PersistentFlags().Lookup("ca"))
@@ -231,6 +233,7 @@ func main(*cobra.Command, []string) error {
 		c.Certificates,
 		viper.GetString("trustCA"),
 		viper.GetStringSlice("ingressClasses"),
+		viper.GetStringSlice("internalCidrRanges"),
 		envoy.WithUpstreamPort(uint32(viper.GetInt32("upstreamPort"))),
 		envoy.WithEnvoyListenerIpv4Address(viper.GetString("envoyListenerIpv4Address")),
 		envoy.WithEnvoyPort(uint32(viper.GetInt32("envoyPort"))),

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -54,6 +54,7 @@ type AccessLogger struct {
 // KubernetesConfigurator takes a given Ingress Class and lister to find only ingresses of that class
 type KubernetesConfigurator struct {
 	ingressClasses             []string
+	internalCidrRanges         []string
 	nodeID                     string
 	syncSecrets                bool
 	certificates               []Certificate
@@ -78,7 +79,7 @@ type KubernetesConfigurator struct {
 }
 
 // NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
-func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, options ...option) *KubernetesConfigurator {
+func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, internalCidrRanges []string, options ...option) *KubernetesConfigurator {
 	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, trustCA: ca}
 	for _, opt := range options {
 		opt(c)

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -80,7 +80,7 @@ type KubernetesConfigurator struct {
 
 // NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
 func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, internalCidrRanges []string, options ...option) *KubernetesConfigurator {
-	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, trustCA: ca}
+	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, trustCA: ca, internalCidrRanges: internalCidrRanges}
 	for _, opt := range options {
 		opt(c)
 	}

--- a/pkg/envoy/configurator_test.go
+++ b/pkg/envoy/configurator_test.go
@@ -52,7 +52,7 @@ func TestGenerate(t *testing.T) {
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*"}, Cert: "b", Key: "c"},
-	}, "d", []string{"bar"})
+	}, "d", []string{"bar"}, []string{"192.168.0.0/16"})
 
 	snapshot, _ := configurator.Generate(ingresses, []*v1.Secret{})
 
@@ -73,7 +73,7 @@ func TestGenerateMultipleCerts(t *testing.T) {
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*.internal.api.co.uk"}, Cert: "couk", Key: "couk"},
-	}, "d", []string{"bar"})
+	}, "d", []string{"bar"}, []string{"192.168.0.0/16"})
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -98,7 +98,7 @@ func TestGenerateMultipleHosts(t *testing.T) {
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com", "*.internal.api.co.uk"}, Cert: "com", Key: "com"},
-	}, "d", []string{"bar"})
+	}, "d", []string{"bar"}, []string{"192.168.0.0/16"})
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -123,7 +123,7 @@ func TestGenerateNoMatchingCert(t *testing.T) {
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
-	}, "d", []string{"bar"})
+	}, "d", []string{"bar"}, []string{"192.168.0.0/16"})
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -145,7 +145,7 @@ func TestGenerateIntoTwoCerts(t *testing.T) {
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*"}, Cert: "all", Key: "all"},
-	}, "d", []string{"bar"})
+	}, "d", []string{"bar"}, []string{"192.168.0.0/16"})
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -218,7 +218,7 @@ func TestGenerateListeners(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			configurator := NewKubernetesConfigurator("a", tc.certs, "", nil)
+			configurator := NewKubernetesConfigurator("a", tc.certs, "", nil, []string{})
 			ret, err := configurator.generateListeners(&envoyConfiguration{VirtualHosts: tc.virtualHost})
 			if err != nil {
 				t.Fatalf("Error generating listeners %v", err)


### PR DESCRIPTION
Adding a new flag `--internal-cidr-ranges` which sets the list of cidr ranges to treat as internal addresses. The default value for the option is set to the [RFC1918 IP addresses](https://datatracker.ietf.org/doc/html/rfc1918#section-3) so this should be backwards compatible:
- `192.168.0.0/16`
- `10.0.0.0/8`
-  `172.16.0.0/12`

envoy v1.29 logs this warning without this change:
> internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step.

