### PR TITLE
feat: add support for sticky-sessions

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -23,7 +23,6 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	previousHosts "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	envoy_extension_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	any "github.com/golang/protobuf/ptypes/any"

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -16,11 +16,15 @@ import (
 	eal "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	gal "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	eauthz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	stateful_session "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
+	cookie_session "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	hcfg "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	tlsInspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	previousHosts "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_extension_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	any "github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
@@ -121,6 +125,40 @@ func makeVirtualHost(vhost *virtualHost, reselectionAttempts int64, defaultRetry
 			},
 		},
 	}
+
+	if vhost.StickySession {
+		cookieConfig := &cookie_session.CookieBasedSessionState{
+			Cookie: &httpv3.Cookie{
+				Name: vhost.StickySessionCookieName,
+				Ttl:  &duration.Duration{Seconds: int64(vhost.StickySessionCookieTTL.Seconds())},
+				Path: vhost.StickySessionCookiePath,
+			},
+		}
+		anyCookieConfig, err := anypb.New(cookieConfig)
+		if err != nil {
+			return &route.VirtualHost{}, fmt.Errorf("failed to marshal cookie session config: %s", err)
+		}
+
+		perRouteConfig := &stateful_session.StatefulSessionPerRoute{
+			Override: &stateful_session.StatefulSessionPerRoute_StatefulSession{
+				StatefulSession: &stateful_session.StatefulSession{
+					SessionState: &core.TypedExtensionConfig{
+						Name:        "envoy.http.stateful_session.cookie",
+						TypedConfig: anyCookieConfig,
+					},
+				},
+			},
+		}
+		anyPerRouteConfig, err := anypb.New(perRouteConfig)
+		if err != nil {
+			return &route.VirtualHost{}, fmt.Errorf("failed to marshal stateful session per-route config: %s", err)
+		}
+
+		virtualHost.TypedPerFilterConfig = map[string]*anypb.Any{
+			statefulSessionFilterName: anyPerRouteConfig,
+		}
+	}
+
 	return &virtualHost, nil
 }
 
@@ -267,6 +305,12 @@ func (c *KubernetesConfigurator) makeConnectionManager(virtualHosts []*route.Vir
 			ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: anyExtAuthzConfig},
 		})
 	}
+
+	statefulSessionFilter, err := makeStatefulSessionFilter()
+	if err != nil {
+		log.Fatalf("failed to create stateful session filter: %s", err)
+	}
+	filterBuilder.Add(statefulSessionFilter)
 
 	filter, err := filterBuilder.Filters()
 	if err != nil {

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -554,6 +554,18 @@ func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPer
 		},
 		HealthChecks: healthChecks,
 	}
+	if c.StickySessionChangeOnFailure != nil && !*c.StickySessionChangeOnFailure {
+		cluster.CommonLbConfig = &v3cluster.Cluster_CommonLbConfig{
+			OverrideHostStatus: &core.HealthStatusSet{
+				Statuses: []core.HealthStatus{
+					core.HealthStatus_UNKNOWN,
+					core.HealthStatus_HEALTHY,
+					core.HealthStatus_UNHEALTHY,
+					core.HealthStatus_DEGRADED,
+				},
+			},
+		}
+	}
 	if outlierPercentage >= 0 {
 		cluster.OutlierDetection = &v3cluster.OutlierDetection{
 			MaxEjectionPercent: &wrappers.UInt32Value{Value: uint32(outlierPercentage)},

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -8,6 +8,8 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	eal "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	stateful_session "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
+	cookie_session "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	"github.com/golang/protobuf/ptypes/duration"
 )
 
@@ -106,4 +108,78 @@ func mustParseDuration(dur string) time.Duration {
 		panic(fmt.Sprintf("Failed test setup: %s", err))
 	}
 	return d
+}
+
+func TestMakeVirtualHostWithStickySession(t *testing.T) {
+	vhost := &virtualHost{
+		Host:                    "app.example.com",
+		UpstreamCluster:         "app_example_com",
+		Timeout:                 15 * time.Second,
+		PerTryTimeout:           5 * time.Second,
+		StickySession:           true,
+		StickySessionCookieName: "my-session",
+		StickySessionCookiePath: "/",
+		StickySessionCookieTTL:  3600 * time.Second,
+	}
+
+	vh, err := makeVirtualHost(vhost, -1, "5xx")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if vh.TypedPerFilterConfig == nil {
+		t.Fatal("expected TypedPerFilterConfig to be set")
+	}
+
+	anyConfig, ok := vh.TypedPerFilterConfig["envoy.filters.http.stateful_session"]
+	if !ok {
+		t.Fatal("expected stateful_session key in TypedPerFilterConfig")
+	}
+
+	perRoute := &stateful_session.StatefulSessionPerRoute{}
+	if err := anyConfig.UnmarshalTo(perRoute); err != nil {
+		t.Fatalf("failed to unmarshal per-route config: %s", err)
+	}
+
+	ss := perRoute.GetStatefulSession()
+	if ss == nil {
+		t.Fatal("expected StatefulSession override, got nil")
+	}
+
+	if ss.SessionState.Name != "envoy.http.stateful_session.cookie" {
+		t.Errorf("expected session state name 'envoy.http.stateful_session.cookie', got '%s'", ss.SessionState.Name)
+	}
+
+	cookieState := &cookie_session.CookieBasedSessionState{}
+	if err := ss.SessionState.TypedConfig.UnmarshalTo(cookieState); err != nil {
+		t.Fatalf("failed to unmarshal cookie config: %s", err)
+	}
+
+	if cookieState.Cookie.Name != "my-session" {
+		t.Errorf("expected cookie name 'my-session', got '%s'", cookieState.Cookie.Name)
+	}
+	if cookieState.Cookie.Ttl.Seconds != 3600 {
+		t.Errorf("expected cookie TTL 3600s, got %d", cookieState.Cookie.Ttl.Seconds)
+	}
+	if cookieState.Cookie.Path != "/" {
+		t.Errorf("expected cookie path '/', got '%s'", cookieState.Cookie.Path)
+	}
+}
+
+func TestMakeVirtualHostWithoutStickySession(t *testing.T) {
+	vhost := &virtualHost{
+		Host:            "app.example.com",
+		UpstreamCluster: "app_example_com",
+		Timeout:         15 * time.Second,
+		PerTryTimeout:   5 * time.Second,
+	}
+
+	vh, err := makeVirtualHost(vhost, -1, "5xx")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if vh.TypedPerFilterConfig != nil {
+		t.Error("expected TypedPerFilterConfig to be nil when sticky session is disabled")
+	}
 }

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -166,6 +166,74 @@ func TestMakeVirtualHostWithStickySession(t *testing.T) {
 	}
 }
 
+func boolPtr(v bool) *bool { return &v }
+
+func TestMakeClusterWithStickySessionOverrideHost(t *testing.T) {
+	c := cluster{
+		Name:                         "test_cluster",
+		VirtualHost:                  "test.example.com",
+		Timeout:                      5 * time.Second,
+		Hosts:                        []LBHost{{"host1", 1}},
+		StickySessionChangeOnFailure: boolPtr(false),
+	}
+	addresses := []*core.Address{
+		{Address: &core.Address_SocketAddress{SocketAddress: &core.SocketAddress{Address: "host1", PortSpecifier: &core.SocketAddress_PortValue{PortValue: 443}}}},
+	}
+	result := makeCluster(c, "", UpstreamHealthCheck{}, -1, addresses)
+
+	if result.CommonLbConfig == nil {
+		t.Fatal("expected CommonLbConfig to be set")
+	}
+	if result.CommonLbConfig.OverrideHostStatus == nil {
+		t.Fatal("expected OverrideHostStatus to be set")
+	}
+	statuses := result.CommonLbConfig.OverrideHostStatus.Statuses
+	if len(statuses) != 4 {
+		t.Fatalf("expected 4 health statuses, got %d", len(statuses))
+	}
+	expected := []core.HealthStatus{core.HealthStatus_UNKNOWN, core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY, core.HealthStatus_DEGRADED}
+	for i, s := range statuses {
+		if s != expected[i] {
+			t.Errorf("expected status %v at index %d, got %v", expected[i], i, s)
+		}
+	}
+}
+
+func TestMakeClusterWithoutStickySessionOverrideHost(t *testing.T) {
+	c := cluster{
+		Name:                         "test_cluster",
+		VirtualHost:                  "test.example.com",
+		Timeout:                      5 * time.Second,
+		Hosts:                        []LBHost{{"host1", 1}},
+		StickySessionChangeOnFailure: boolPtr(true),
+	}
+	addresses := []*core.Address{
+		{Address: &core.Address_SocketAddress{SocketAddress: &core.SocketAddress{Address: "host1", PortSpecifier: &core.SocketAddress_PortValue{PortValue: 443}}}},
+	}
+	result := makeCluster(c, "", UpstreamHealthCheck{}, -1, addresses)
+
+	if result.CommonLbConfig != nil {
+		t.Error("expected CommonLbConfig to be nil when StickySessionChangeOnFailure is true")
+	}
+}
+
+func TestMakeClusterWithStickySessionNil(t *testing.T) {
+	c := cluster{
+		Name:        "test_cluster",
+		VirtualHost: "test.example.com",
+		Timeout:     5 * time.Second,
+		Hosts:       []LBHost{{"host1", 1}},
+	}
+	addresses := []*core.Address{
+		{Address: &core.Address_SocketAddress{SocketAddress: &core.SocketAddress{Address: "host1", PortSpecifier: &core.SocketAddress_PortValue{PortValue: 443}}}},
+	}
+	result := makeCluster(c, "", UpstreamHealthCheck{}, -1, addresses)
+
+	if result.CommonLbConfig != nil {
+		t.Error("expected CommonLbConfig to be nil when StickySessionChangeOnFailure is nil (sticky sessions disabled)")
+	}
+}
+
 func TestMakeVirtualHostWithoutStickySession(t *testing.T) {
 	vhost := &virtualHost{
 		Host:            "app.example.com",

--- a/pkg/envoy/http_filters.go
+++ b/pkg/envoy/http_filters.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	stateful_session "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const statefulSessionFilterName = "envoy.filters.http.stateful_session"
 
 type httpFilterBuilder struct {
 	filters []*hcm.HttpFilter
@@ -15,6 +18,18 @@ type httpFilterBuilder struct {
 func (b *httpFilterBuilder) Add(filter *hcm.HttpFilter) *httpFilterBuilder {
 	b.filters = append(b.filters, filter)
 	return b
+}
+
+func makeStatefulSessionFilter() (*hcm.HttpFilter, error) {
+	statefulSessionConfig := &stateful_session.StatefulSession{}
+	anyConfig, err := anypb.New(statefulSessionConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal stateful session config: %s", err)
+	}
+	return &hcm.HttpFilter{
+		Name:       statefulSessionFilterName,
+		ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: anyConfig},
+	}, nil
 }
 
 func (b *httpFilterBuilder) Filters() ([]*hcm.HttpFilter, error) {

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -106,11 +106,22 @@ type LBHost struct {
 }
 
 type cluster struct {
-	Name            string
-	VirtualHost     string
-	HealthCheckPath string
-	Timeout         time.Duration
-	Hosts           []LBHost
+	Name                         string
+	VirtualHost                  string
+	HealthCheckPath              string
+	Timeout                      time.Duration
+	Hosts                        []LBHost
+	StickySessionChangeOnFailure *bool // nil = not set (sticky sessions disabled), false = persist to unhealthy backend
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 func (c *cluster) identity() string {
@@ -139,6 +150,10 @@ func (c *cluster) Equals(other *cluster) bool {
 	}
 
 	if len(c.Hosts) != len(other.Hosts) {
+		return false
+	}
+
+	if !boolPtrEqual(c.StickySessionChangeOnFailure, other.StickySessionChangeOnFailure) {
 		return false
 	}
 
@@ -339,6 +354,9 @@ func (envoyIng *envoyIngress) addStickySession(ingress *k8s.Ingress) {
 	envoyIng.vhost.StickySessionCookieName = cookieName
 	envoyIng.vhost.StickySessionCookiePath = cookiePath
 	envoyIng.vhost.StickySessionCookieTTL = cookieTTL
+
+	changeOnFailure := ingress.Annotations["yggdrasil.uswitch.com/sticky-session-change-on-failure"] != "false"
+	envoyIng.cluster.StickySessionChangeOnFailure = &changeOnFailure
 }
 
 func (envoyIng *envoyIngress) addRetryOn(ingress *k8s.Ingress) {

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -75,6 +75,11 @@ type virtualHost struct {
 	TlsKey          string
 	TlsCert         string
 	RetryOn         string
+
+	StickySession           bool
+	StickySessionCookieName string
+	StickySessionCookiePath string
+	StickySessionCookieTTL  time.Duration
 }
 
 func (v *virtualHost) Equals(other *virtualHost) bool {
@@ -88,7 +93,11 @@ func (v *virtualHost) Equals(other *virtualHost) bool {
 		v.PerTryTimeout == other.PerTryTimeout &&
 		v.TlsKey == other.TlsKey &&
 		v.TlsCert == other.TlsCert &&
-		v.RetryOn == other.RetryOn
+		v.RetryOn == other.RetryOn &&
+		v.StickySession == other.StickySession &&
+		v.StickySessionCookieName == other.StickySessionCookieName &&
+		v.StickySessionCookiePath == other.StickySessionCookiePath &&
+		v.StickySessionCookieTTL == other.StickySessionCookieTTL
 }
 
 type LBHost struct {
@@ -309,6 +318,29 @@ func validateTlsSecret(secret *v1.Secret) (bool, error) {
 	return true, nil
 }
 
+func (envoyIng *envoyIngress) addStickySession(ingress *k8s.Ingress) {
+	if ingress.Annotations["yggdrasil.uswitch.com/sticky-sessions"] != "true" {
+		return
+	}
+	cookieName := ingress.Annotations["yggdrasil.uswitch.com/sticky-session-cookie-name"]
+	cookiePath := ingress.Annotations["yggdrasil.uswitch.com/sticky-session-cookie-path"]
+	cookieTTLStr := ingress.Annotations["yggdrasil.uswitch.com/sticky-session-cookie-ttl"]
+
+	if cookieName == "" || cookiePath == "" || cookieTTLStr == "" {
+		logrus.Warnf("sticky-sessions enabled for ingress %s/%s but missing required annotations (cookie-name, cookie-path, cookie-ttl), skipping sticky sessions", ingress.Namespace, ingress.Name)
+		return
+	}
+	cookieTTL, err := time.ParseDuration(cookieTTLStr)
+	if err != nil {
+		logrus.Warnf("invalid sticky-session-cookie-ttl for ingress %s/%s: %s", ingress.Namespace, ingress.Name, err)
+		return
+	}
+	envoyIng.vhost.StickySession = true
+	envoyIng.vhost.StickySessionCookieName = cookieName
+	envoyIng.vhost.StickySessionCookiePath = cookiePath
+	envoyIng.vhost.StickySessionCookieTTL = cookieTTL
+}
+
 func (envoyIng *envoyIngress) addRetryOn(ingress *k8s.Ingress) {
 	if ingress.Annotations["yggdrasil.uswitch.com/retry-on"] != "" {
 		retryOn := ingress.Annotations["yggdrasil.uswitch.com/retry-on"]
@@ -375,6 +407,8 @@ func translateIngresses(ingresses []*k8s.Ingress, syncSecrets bool, secrets []*v
 				}
 
 				envoyIngress.addRetryOn(i)
+
+				envoyIngress.addStickySession(i)
 
 				if syncSecrets && envoyIngress.vhost.TlsKey == "" && envoyIngress.vhost.TlsCert == "" {
 					if hostTlsSecret, err := getHostTlsSecret(i, ruleHost, secrets); err != nil {

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -128,6 +128,22 @@ func TestVirtualHostEquality(t *testing.T) {
 	if a.Equals(e) {
 		t.Error("virtual hosts with different per try timeout values should not be equal")
 	}
+
+	f := &virtualHost{Host: "foo", StickySession: true, StickySessionCookieName: "sess", StickySessionCookiePath: "/", StickySessionCookieTTL: 3600 * time.Second}
+	if a.Equals(f) {
+		t.Error("virtual hosts with different sticky session values should not be equal")
+	}
+
+	g := &virtualHost{Host: "foo", StickySession: true, StickySessionCookieName: "sess", StickySessionCookiePath: "/", StickySessionCookieTTL: 3600 * time.Second}
+	h := &virtualHost{Host: "foo", StickySession: true, StickySessionCookieName: "sess", StickySessionCookiePath: "/", StickySessionCookieTTL: 3600 * time.Second}
+	if !g.Equals(h) {
+		t.Error("virtual hosts with same sticky session values should be equal")
+	}
+
+	i := &virtualHost{Host: "foo", StickySession: true, StickySessionCookieName: "different", StickySessionCookiePath: "/", StickySessionCookieTTL: 3600 * time.Second}
+	if g.Equals(i) {
+		t.Error("virtual hosts with different sticky session cookie names should not be equal")
+	}
 }
 
 func TestClusterEquality(t *testing.T) {
@@ -600,6 +616,20 @@ func newGenericIngress(specHost string, loadbalancerHost string) *k8s.Ingress {
 	}
 }
 
+func newGenericIngressWithAnnotations(specHost string, loadbalancerHost string, annotations map[string]string) *k8s.Ingress {
+	mergedAnnotations := map[string]string{
+		"kubernetes.io/ingress.class": "bar",
+	}
+	for k, v := range annotations {
+		mergedAnnotations[k] = v
+	}
+	return &k8s.Ingress{
+		Annotations: mergedAnnotations,
+		RulesHosts:  []string{specHost},
+		Upstreams:   []string{loadbalancerHost},
+	}
+}
+
 func newIngressIP(specHost string, loadbalancerHost string) *k8s.Ingress {
 	return &k8s.Ingress{
 		Annotations: map[string]string{
@@ -607,5 +637,73 @@ func newIngressIP(specHost string, loadbalancerHost string) *k8s.Ingress {
 		},
 		RulesHosts: []string{specHost},
 		Upstreams:  []string{loadbalancerHost},
+	}
+}
+
+func TestStickySessionAnnotationParsing(t *testing.T) {
+	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
+		"yggdrasil.uswitch.com/sticky-sessions":            "true",
+		"yggdrasil.uswitch.com/sticky-session-cookie-name": "my-session",
+		"yggdrasil.uswitch.com/sticky-session-cookie-path": "/",
+		"yggdrasil.uswitch.com/sticky-session-cookie-ttl":  "3600s",
+	})
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.VirtualHosts) != 1 {
+		t.Fatal("expected 1 virtual host")
+	}
+	vhost := c.VirtualHosts[0]
+	if !vhost.StickySession {
+		t.Error("expected StickySession to be true")
+	}
+	if vhost.StickySessionCookieName != "my-session" {
+		t.Errorf("expected cookie name 'my-session', got '%s'", vhost.StickySessionCookieName)
+	}
+	if vhost.StickySessionCookiePath != "/" {
+		t.Errorf("expected cookie path '/', got '%s'", vhost.StickySessionCookiePath)
+	}
+	if vhost.StickySessionCookieTTL != 3600*time.Second {
+		t.Errorf("expected cookie TTL 3600s, got %v", vhost.StickySessionCookieTTL)
+	}
+}
+
+func TestStickySessionMissingAnnotations(t *testing.T) {
+	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
+		"yggdrasil.uswitch.com/sticky-sessions": "true",
+	})
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.VirtualHosts) != 1 {
+		t.Fatal("expected 1 virtual host")
+	}
+	if c.VirtualHosts[0].StickySession {
+		t.Error("expected StickySession to be false when required annotations are missing")
+	}
+}
+
+func TestStickySessionDisabled(t *testing.T) {
+	ingress := newGenericIngress("app.com", "foo.com")
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.VirtualHosts) != 1 {
+		t.Fatal("expected 1 virtual host")
+	}
+	if c.VirtualHosts[0].StickySession {
+		t.Error("expected StickySession to be false when annotation is absent")
 	}
 }

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -691,6 +691,70 @@ func TestStickySessionMissingAnnotations(t *testing.T) {
 	}
 }
 
+func TestStickySessionChangeOnFailureFalse(t *testing.T) {
+	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
+		"yggdrasil.uswitch.com/sticky-sessions":                      "true",
+		"yggdrasil.uswitch.com/sticky-session-cookie-name":           "my-session",
+		"yggdrasil.uswitch.com/sticky-session-cookie-path":           "/",
+		"yggdrasil.uswitch.com/sticky-session-cookie-ttl":            "3600s",
+		"yggdrasil.uswitch.com/sticky-session-change-on-failure": "false",
+	})
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.Clusters) != 1 {
+		t.Fatal("expected 1 cluster")
+	}
+	if c.Clusters[0].StickySessionChangeOnFailure == nil || *c.Clusters[0].StickySessionChangeOnFailure {
+		t.Error("expected StickySessionChangeOnFailure to be false")
+	}
+}
+
+func TestStickySessionChangeOnFailureDefault(t *testing.T) {
+	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
+		"yggdrasil.uswitch.com/sticky-sessions":            "true",
+		"yggdrasil.uswitch.com/sticky-session-cookie-name": "my-session",
+		"yggdrasil.uswitch.com/sticky-session-cookie-path": "/",
+		"yggdrasil.uswitch.com/sticky-session-cookie-ttl":  "3600s",
+	})
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.Clusters) != 1 {
+		t.Fatal("expected 1 cluster")
+	}
+	if c.Clusters[0].StickySessionChangeOnFailure == nil || !*c.Clusters[0].StickySessionChangeOnFailure {
+		t.Error("expected StickySessionChangeOnFailure to be true by default")
+	}
+}
+
+func TestStickySessionChangeOnFailureWithoutStickySessions(t *testing.T) {
+	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
+		"yggdrasil.uswitch.com/sticky-session-change-on-failure": "false",
+	})
+	timeouts := DefaultTimeouts{
+		Cluster: 30 * time.Second,
+		Route:   15 * time.Second,
+		PerTry:  5 * time.Second,
+	}
+	c := translateIngresses([]*k8s.Ingress{ingress}, false, []*v1.Secret{}, timeouts, "/var/log/envoy/")
+
+	if len(c.Clusters) != 1 {
+		t.Fatal("expected 1 cluster")
+	}
+	if c.Clusters[0].StickySessionChangeOnFailure != nil {
+		t.Error("expected StickySessionChangeOnFailure to be nil when sticky sessions are disabled")
+	}
+}
+
 func TestStickySessionDisabled(t *testing.T) {
 	ingress := newGenericIngress("app.com", "foo.com")
 	timeouts := DefaultTimeouts{


### PR DESCRIPTION
Add sticky session support via Envoy's stateful session filter using cookie-based affinity.

### Features
- **Sticky sessions**: Route requests to the same upstream using a configurable session cookie
- **Failure behavior control**: Option to persist routing to unhealthy backends or re-route on failure

### Annotations
| Annotation | Description |
|---|---|
| `yggdrasil.uswitch.com/sticky-sessions` | Enable sticky sessions (`"true"`) |
| `yggdrasil.uswitch.com/sticky-session-cookie-name` | Cookie name |
| `yggdrasil.uswitch.com/sticky-session-cookie-path` | Cookie path |
| `yggdrasil.uswitch.com/sticky-session-cookie-ttl` | Cookie TTL (e.g. `"3600s"`) |
| `yggdrasil.uswitch.com/sticky-session-change-on-failure` | Re-route on backend failure (`"true"`/`"false"`, default `"true"`) |
